### PR TITLE
Change meteor compass to target chest

### DIFF
--- a/src/main/java/appeng/block/storage/BlockSkyChest.java
+++ b/src/main/java/appeng/block/storage/BlockSkyChest.java
@@ -26,6 +26,8 @@ import appeng.helpers.ICustomCollision;
 import appeng.tile.storage.TileSkyChest;
 import appeng.util.Platform;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.properties.PropertyBool;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
@@ -48,6 +50,8 @@ public class BlockSkyChest extends AEBaseTileBlock implements ICustomCollision {
     private static final double AABB_OFFSET_SIDES = 0.06;
     private static final double AABB_OFFSET_TOP = 0.125;
 
+    public static final PropertyBool NATURAL = PropertyBool.create("natural");
+
     public enum SkyChestType {
         STONE, BLOCK
     }
@@ -61,6 +65,22 @@ public class BlockSkyChest extends AEBaseTileBlock implements ICustomCollision {
         this.setHardness(50);
         this.blockResistance = 150.0f;
         this.type = type;
+        setDefaultState(getDefaultState().withProperty(NATURAL, true));
+    }
+
+    @Override
+    protected IProperty[] getAEStates() {
+        return new IProperty[]{NATURAL};
+    }
+
+    @Override
+    public int getMetaFromState(IBlockState state) {
+        return state.getValue(NATURAL) ? 1 : 0;
+    }
+
+    @Override
+    public IBlockState getStateFromMeta(int meta) {
+        return getDefaultState().withProperty(NATURAL, meta == 1);
     }
 
     @Override

--- a/src/main/java/appeng/services/CompassService.java
+++ b/src/main/java/appeng/services/CompassService.java
@@ -21,11 +21,13 @@ package appeng.services;
 
 import appeng.api.AEApi;
 import appeng.api.util.DimensionalCoord;
+import appeng.block.storage.BlockSkyChest;
 import appeng.services.compass.CompassReader;
 import appeng.services.compass.ICompassCallback;
 import appeng.util.Platform;
 import com.google.common.base.Preconditions;
 import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.event.world.WorldEvent;
@@ -117,15 +119,19 @@ public final class CompassService {
         // lower level...
         final Chunk c = w.getChunk(cx, cz);
 
-        Optional<Block> maybeBlock = AEApi.instance().definitions().blocks().skyStoneBlock().maybeBlock();
+        Optional<Block> maybeBlock = AEApi.instance().definitions().blocks().skyStoneChest().maybeBlock();
         if (maybeBlock.isPresent()) {
-            Block skyStoneBlock = maybeBlock.get();
+            Block skyStoneChest = maybeBlock.get();
             for (int i = 0; i < CHUNK_SIZE; i++) {
                 for (int j = 0; j < CHUNK_SIZE; j++) {
                     for (int k = low_y; k < hi_y; k++) {
-                        final Block blk = c.getBlockState(i, k, j).getBlock();
-                        if (blk == skyStoneBlock) {
-                            return this.executor.submit(new CMUpdatePost(w, cx, cz, cdy, true));
+                        final IBlockState state = c.getBlockState(i, k, j);
+                        final Block blk = state.getBlock();
+                        if (blk == skyStoneChest) {
+                            if (state.getPropertyKeys().contains(BlockSkyChest.NATURAL)
+                                    && state.getValue(BlockSkyChest.NATURAL)) {
+                                return this.executor.submit(new CMUpdatePost(w, cx, cz, cdy, true));
+                            }
                         }
                     }
                 }

--- a/src/main/java/appeng/worldgen/MeteoritePlacer.java
+++ b/src/main/java/appeng/worldgen/MeteoritePlacer.java
@@ -23,6 +23,7 @@ import appeng.api.AEApi;
 import appeng.api.definitions.IBlockDefinition;
 import appeng.api.definitions.IBlocks;
 import appeng.api.definitions.IMaterials;
+import appeng.block.storage.BlockSkyChest;
 import appeng.core.AEConfig;
 import appeng.core.features.AEFeature;
 import appeng.core.worlddata.WorldData;
@@ -192,7 +193,8 @@ public final class MeteoritePlacer {
         this.skyStoneDefinition.maybeBlock().ifPresent(block -> this.placeMeteoriteSkyStone(w, x, y, z, block));
 
         if (AEConfig.instance().isFeatureEnabled(AEFeature.SPAWN_PRESSES_IN_METEORITES)) {
-            this.skyChestDefinition.maybeBlock().ifPresent(block -> this.putter.put(w, x, y, z, block));
+            this.skyChestDefinition.maybeBlock().ifPresent(block -> this.putter.put(w, x, y, z,
+                            block.getDefaultState().withProperty(BlockSkyChest.NATURAL, true)));
 
             final TileEntity te = w.getTileEntity(x, y, z);
             final InventoryAdaptor ap = InventoryAdaptor.getAdaptor(te, EnumFacing.UP);

--- a/src/main/java/appeng/worldgen/meteorite/FalloutCopy.java
+++ b/src/main/java/appeng/worldgen/meteorite/FalloutCopy.java
@@ -42,7 +42,7 @@ public class FalloutCopy extends Fallout {
     public void getRandomFall(final IMeteoriteWorld w, final int x, final int y, final int z) {
         final double a = Math.random();
         if (a > SPECIFIED_BLOCK_THRESHOLD) {
-            this.putter.put(w, x, y, z, this.block, 3);
+            this.putter.put(w, x, y, z, this.block);
         } else {
             this.getOther(w, x, y, z, a);
         }
@@ -56,7 +56,7 @@ public class FalloutCopy extends Fallout {
     public void getRandomInset(final IMeteoriteWorld w, final int x, final int y, final int z) {
         final double a = Math.random();
         if (a > SPECIFIED_BLOCK_THRESHOLD) {
-            this.putter.put(w, x, y, z, this.block, 3);
+            this.putter.put(w, x, y, z, this.block);
         } else if (a > AIR_BLOCK_THRESHOLD) {
             this.putter.put(w, x, y, z, Platform.AIR_BLOCK);
         } else {

--- a/src/main/java/appeng/worldgen/meteorite/MeteoriteBlockPutter.java
+++ b/src/main/java/appeng/worldgen/meteorite/MeteoriteBlockPutter.java
@@ -36,7 +36,7 @@ public class MeteoriteBlockPutter {
         return true;
     }
 
-    void put(final IMeteoriteWorld w, final int i, final int j, final int k, final IBlockState state, final int meta) {
+    public void put(final IMeteoriteWorld w, final int i, final int j, final int k, final IBlockState state) {
         if (w.getBlock(i, j, k) == Blocks.BEDROCK) {
             return;
         }

--- a/src/main/resources/assets/appliedenergistics2/blockstates/sky_stone_chest.json
+++ b/src/main/resources/assets/appliedenergistics2/blockstates/sky_stone_chest.json
@@ -1,8 +1,13 @@
 {
     "__comment": "This block is rendered via TESR, so this is only used for the particle texture.",
+    "forge_marker": 1,
+    "defaults": {
+        "model": "appliedenergistics2:sky_stone_block"
+    },
     "variants": {
-        "normal": {
-            "model": "appliedenergistics2:sky_stone_block"
+        "natural": {
+            "true": {},
+            "false": {}
         }
     }
 }


### PR DESCRIPTION
Closes #284 

Changes meteorite compass to target skystone chest instead of skystone block

Also sets the chest with a `natural` blockstate property so that player-placed skystone chests will not be targeted

Removed the `meta` field from `MeteoriteBlockPutter#put` because it was unused, and was previously a package-private method so it should not cause any issues