### PR TITLE
Fix Level Emitter Buttons and fix ME IO Port not respecting it's redstone mode.

### DIFF
--- a/src/main/java/appeng/block/storage/BlockIOPort.java
+++ b/src/main/java/appeng/block/storage/BlockIOPort.java
@@ -68,9 +68,9 @@ public class BlockIOPort extends AEBaseTileBlock {
     public void neighborChanged(IBlockState state, World world, BlockPos pos, Block blockIn, BlockPos fromPos) {
         final TileIOPort te = this.getTileEntity(world, pos);
         if (te != null) {
-	    if (te.getInstalledUpgrades(Upgrades.REDSTONE) != 0) {
-		te.updateRedstoneState();
-	    }
+            if (te.getInstalledUpgrades(Upgrades.REDSTONE) != 0) {
+                te.updateRedstoneState();
+            }
         }
     }
 

--- a/src/main/java/appeng/block/storage/BlockIOPort.java
+++ b/src/main/java/appeng/block/storage/BlockIOPort.java
@@ -19,6 +19,7 @@
 package appeng.block.storage;
 
 
+import appeng.api.config.Upgrades;
 import appeng.api.util.AEPartLocation;
 import appeng.block.AEBaseTileBlock;
 import appeng.core.sync.GuiBridge;
@@ -67,7 +68,9 @@ public class BlockIOPort extends AEBaseTileBlock {
     public void neighborChanged(IBlockState state, World world, BlockPos pos, Block blockIn, BlockPos fromPos) {
         final TileIOPort te = this.getTileEntity(world, pos);
         if (te != null) {
-            te.updateRedstoneState();
+	    if (te.getInstalledUpgrades(Upgrades.REDSTONE) != 0) {
+		te.updateRedstoneState();
+	    }
         }
     }
 

--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -268,7 +268,7 @@ public final class AEConfig extends Configuration implements IConfigurableObject
 
             this.craftByStacks[btnNum] = Math.abs(cmb.getInt(this.craftByStacks[btnNum]));
             this.priorityByStacks[btnNum] = Math.abs(pmb.getInt(this.priorityByStacks[btnNum]));
-            this.levelByStacks[btnNum] = Math.abs(pmb.getInt(this.levelByStacks[btnNum]));
+            this.levelByStacks[btnNum] = Math.abs(lmb.getInt(this.levelByStacks[btnNum]));
 
             cmb.setComment("Controls buttons on Crafting Screen : Capped at " + buttonCap);
             pmb.setComment("Controls buttons on Priority Screen : Capped at " + buttonCap);

--- a/src/main/java/appeng/tile/storage/TileIOPort.java
+++ b/src/main/java/appeng/tile/storage/TileIOPort.java
@@ -183,11 +183,11 @@ public class TileIOPort extends AENetworkInvTile implements IUpgradeableHost, IC
         if (this.lastRedstoneState != currentState) {
             this.lastRedstoneState = currentState;
             this.updateTask();
-	    if (currentState == YesNo.YES) {
-		if (this.manager.getSetting(Settings.REDSTONE_CONTROLLED) == RedstoneMode.SIGNAL_PULSE) {
-		this.doWork();
-		}
-	    }
+            if (currentState == YesNo.YES) {
+                if (this.manager.getSetting(Settings.REDSTONE_CONTROLLED) == RedstoneMode.SIGNAL_PULSE) {
+                    this.doWork();
+                }
+            }
         }
     }
 
@@ -204,20 +204,20 @@ public class TileIOPort extends AENetworkInvTile implements IUpgradeableHost, IC
             return true;
         }
         final RedstoneMode rs = (RedstoneMode) this.manager.getSetting(Settings.REDSTONE_CONTROLLED);
-	switch (rs) {
-                case IGNORE:
-                    return true;
+        switch (rs) {
+            case IGNORE:
+                return true;
 
-                case HIGH_SIGNAL:
-                    return this.getRedstoneState();
+            case HIGH_SIGNAL:
+                return this.getRedstoneState();
 
-                case LOW_SIGNAL:
-		    return !this.getRedstoneState();
+            case LOW_SIGNAL:
+                return !this.getRedstoneState();
 
-                case SIGNAL_PULSE:
-                default:
-                    return false;
-            }
+            case SIGNAL_PULSE:
+            default:
+                return false;
+        }
     }
 
     @Override
@@ -282,11 +282,11 @@ public class TileIOPort extends AENetworkInvTile implements IUpgradeableHost, IC
         if (!this.getProxy().isActive()) {
             return TickRateModulation.IDLE;
         }
-	return this.doWork();
+        return this.doWork();
     }
 
     private TickRateModulation doWork() {
-	TickRateModulation ret = TickRateModulation.SLEEP;
+        TickRateModulation ret = TickRateModulation.SLEEP;
         long itemsToMove = 256;
 
         switch (this.getInstalledUpgrades(Upgrades.SPEED)) {


### PR DESCRIPTION
Title basically. 
The Level Emitter's buttons were using the priority button's config for their values, seemingly because of a typo, so I fixed the typo. 

And the IO Port could either be disabled by redstone or enabled by redstone, never pulsed or ignoring redstone. Since the IO Port has those as redstone modes as options, I assumed it's a bug and added code to the IO Port to allow pulsing and ignoring. This is will be my first time contributing to a real mod, so I don't know if my implementation is the most optimal. But, this change only affects the IO Port and I can't think of a better way, so it's probably fine.