### PR TITLE
Fix 2 cable rendering bugs

### DIFF
--- a/src/main/java/appeng/client/render/cablebus/CableBuilder.java
+++ b/src/main/java/appeng/client/render/cablebus/CableBuilder.java
@@ -331,6 +331,10 @@ class CableBuilder {
         TextureAtlasSprite oddChannel = this.smartCableTextures.getOddTextureForChannels((int) (channels / (AEConfig.instance().getNormalChannelCapacity() / 8)));
         TextureAtlasSprite evenChannel = this.smartCableTextures.getEvenTextureForChannels((int) (channels / (AEConfig.instance().getNormalChannelCapacity() / 8)));
 
+        // Thin part of connector, here to prevent the color of the channels
+        // from leaking into it
+        addCoveredCableSizedCube(facing, cubeBuilder);
+
         // For to-machine connections, use a thicker end-cap for the connection
         if (connectionType != AECableType.GLASS && !cableBusAdjacent) {
             this.addBigCoveredCableSizedCube(facing, cubeBuilder);
@@ -351,7 +355,6 @@ class CableBuilder {
             cubeBuilder.setTexture(texture);
         }
 
-        addCoveredCableSizedCube(facing, cubeBuilder);
 
         // Render the channel indicators brightly lit at night
         cubeBuilder.setRenderFullBright(true);

--- a/src/main/java/appeng/parts/CableBusContainer.java
+++ b/src/main/java/appeng/parts/CableBusContainer.java
@@ -974,14 +974,6 @@ public class CableBusContainer extends CableBusStorage implements AEMultiTile, I
                     connectionType = AECableType.min(connectionType, adjacentType);
                 }
 
-                // Check if the adjacent TE is a cable bus or not
-                if (adjacentTe instanceof IPartHost) {
-                    IPartHost host = (IPartHost) adjacentTe;
-                    if (host.getPart(facing) != null) {
-                        renderState.getCableBusAdjacent().add(facing);
-                    }
-                }
-
                 renderState.getConnectionTypes().put(facing, connectionType);
             }
 


### PR DESCRIPTION
### Incorrect Connector Sizes
Commit https://github.com/AE2-UEL/Applied-Energistics-2/pull/335/commits/c3e8cb30815e62de7373aa7849d5acda11a0d140 in PR https://github.com/AE2-UEL/Applied-Energistics-2/pull/335 seems to have introduced a bug with covered and smart cable rendering connections. Specifically the bug is when one cable connects to another cable that has a part facing the same way as the connection. Another thing to note is that this was fixed by making cables not add anything to the adjacent cable bus list in CableBusRenderState. Since the cables seem to be the only thing that uses the adjacent cable bus list it might be best to remove everything related to it, to marginally improve render times. But that seems like a decently big decision that I'll leave up to the maintainers. And I have played with this a bit and haven't seen any rendering bugs, so I think the adjacent list is only used for the special cable rendering.

Old look: note the left side is incorrectly just thin connectors due to having a part on each cable
![incorrect connector sizes](https://github.com/AE2-UEL/Applied-Energistics-2/assets/93405381/1cc63883-9488-4f2c-84d4-4505a7e9f0c0)

New look:
![fixed connector sizes](https://github.com/AE2-UEL/Applied-Energistics-2/assets/93405381/1e02743f-bffa-49d7-9348-9f87fdedee6a)




### Incorrect Smart Connector Colors
Because the CableBuilder did not reset the color of the cubeBuilder before drawing the thin connector, the coloring applied to the channel textures would leak onto the thin connector's texture.  This  is actually pretty unnoticeable since most cable colors have similar texture colors to channel colors, but it's most notable on fluix because fluix has purple channels while the texture is gray.
and to clarify the thin connector is the one pixel wide connector that connects the main cable width with the core of the cable

Old look: 
![incorrect connector color](https://github.com/AE2-UEL/Applied-Energistics-2/assets/93405381/f0404c23-c31e-4258-8e0c-7f77e0390a34)

New look:
![fixed connector color](https://github.com/AE2-UEL/Applied-Energistics-2/assets/93405381/191ad3d3-5e25-417d-a5b8-c6b684068d29)



