### PR TITLE
Use Cache instead of HashMap when gathering CableBusBakedModels

### DIFF
--- a/src/main/java/appeng/client/render/cablebus/CableBusModel.java
+++ b/src/main/java/appeng/client/render/cablebus/CableBusModel.java
@@ -110,7 +110,7 @@ public class CableBusModel implements IModel, ISelectiveResourceReloadListener {
     @Override
     public void onResourceManagerReload(IResourceManager resourceManager, Predicate<IResourceType> resourcePredicate) {
         if (resourcePredicate.test(VanillaResourceType.MODELS)) {
-            CableBusBakedModel.CABLE_MODEL_CACHE.clear();
+            CableBusBakedModel.CABLE_MODEL_CACHE.invalidateAll();
         }
     }
 


### PR DESCRIPTION
Directed logging to `AELog#error` when the cache throws an `ExecutionException`, feel free to change that if needed.

This was caught when running in Java 9+ where `computeIfAbsent` is eligible to now throw a `ConcurrentModificationException`.