### PR TITLE
Fix incorrect CellInventory field types

### DIFF
--- a/src/main/java/appeng/me/storage/BasicCellInventory.java
+++ b/src/main/java/appeng/me/storage/BasicCellInventory.java
@@ -205,7 +205,7 @@ public class BasicCellInventory<T extends IAEStack<T>> extends AbstractCellInven
     }
 
     @Override
-    protected boolean loadCellItem(NBTTagCompound compoundTag, int stackSize) {
+    protected boolean loadCellItem(NBTTagCompound compoundTag, long stackSize) {
         // Now load the item stack
         final T t;
         try {


### PR DESCRIPTION
Fixes additional data losses not covered in https://github.com/AE2-UEL/Applied-Energistics-2/pull/327. Enables natural support for larger cells and prevents them from overflowing past the `int` limit. Cells with `int` tags seamlessly migrate to `long` without regression.

The only minor concern is the change in signature for `BasicCellInventory#loadCellItem(NBTTagCompound, int)`, which now accepts `long`s instead. This is not being overridden by mainstream mods such as EC2 or Thaumic Energistics, however.

Mostly on par with https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/234, except for native larger cells.
