### PR TITLE
Fix IO port getting stuck in some situations

### DIFF
--- a/src/main/java/appeng/tile/storage/TileIOPort.java
+++ b/src/main/java/appeng/tile/storage/TileIOPort.java
@@ -178,6 +178,12 @@ public class TileIOPort extends AENetworkInvTile implements IUpgradeableHost, IC
         }
     }
 
+    @Override
+    public void gridChanged() {
+        super.gridChanged();
+        updateTask();
+    }
+
     public void updateRedstoneState() {
         final YesNo currentState = this.world.getRedstonePowerFromNeighbors(this.pos) != 0 ? YesNo.YES : YesNo.NO;
         if (this.lastRedstoneState != currentState) {


### PR DESCRIPTION
Primarily happens when restarting the server/singleplayer world, sometimes the transfer operation won't work until some other update