### PR TITLE
Update mod base name

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ aebuild=7
 includeMCVersionJar = false
 
 # The name of your jar when you produce builds, not including any versioning info
-modArchivesBaseName = appliedenergistics2
+modArchivesBaseName = ae2-uel
 
 # Will update your build.gradle automatically whenever an update is available
 autoUpdateBuildScript = false


### PR DESCRIPTION
Since we've moved away from the original versioning scheme, we should probably rename the jar name to `ae2-uel` to avoid confusing the fork with the original mod. Alternatively, `appeng2-uel` or `appliedenergistics2-uel` could work.