### PR TITLE
Fix ME Storage Buses reporting contents regardless of settings

### DIFF
--- a/src/main/java/appeng/me/storage/MEInventoryHandler.java
+++ b/src/main/java/appeng/me/storage/MEInventoryHandler.java
@@ -22,6 +22,7 @@ package appeng.me.storage;
 import appeng.api.config.AccessRestriction;
 import appeng.api.config.Actionable;
 import appeng.api.config.IncludeExclude;
+import appeng.api.config.StorageFilter;
 import appeng.api.networking.security.IActionSource;
 import appeng.api.storage.IMEInventory;
 import appeng.api.storage.IMEInventoryHandler;
@@ -38,12 +39,14 @@ public class MEInventoryHandler<T extends IAEStack<T>> implements IMEInventoryHa
     private int myPriority;
     private IncludeExclude myWhitelist;
     private AccessRestriction myAccess;
+    private StorageFilter storageFilter;
     private IPartitionList<T> myPartitionList;
 
     private AccessRestriction cachedAccessRestriction;
     private boolean hasReadAccess;
     private boolean hasWriteAccess;
     private boolean isSticky;
+    private boolean gettingAvailableContent;
 
     public MEInventoryHandler(final IMEInventory<T> i, final IStorageChannel<T> channel) {
         if (i instanceof IMEInventoryHandler) {
@@ -77,7 +80,7 @@ public class MEInventoryHandler<T extends IAEStack<T>> implements IMEInventoryHa
         this.hasWriteAccess = this.cachedAccessRestriction.hasPermission(AccessRestriction.WRITE);
     }
 
-    IPartitionList<T> getPartitionList() {
+    public IPartitionList<T> getPartitionList() {
         return this.myPartitionList;
     }
 
@@ -96,7 +99,7 @@ public class MEInventoryHandler<T extends IAEStack<T>> implements IMEInventoryHa
 
     @Override
     public T extractItems(final T request, final Actionable type, final IActionSource src) {
-        if (!this.hasReadAccess) {
+        if (!this.canExtract(request)) {
             return null;
         }
 
@@ -105,11 +108,27 @@ public class MEInventoryHandler<T extends IAEStack<T>> implements IMEInventoryHa
 
     @Override
     public IItemList<T> getAvailableItems(final IItemList<T> out) {
-        if (!this.hasReadAccess) {
+        if (this.gettingAvailableContent || !this.hasReadAccess) {
             return out;
         }
 
-        return this.internal.getAvailableItems(out);
+        this.gettingAvailableContent = true;
+        try {
+            if (this.storageFilter == StorageFilter.EXTRACTABLE_ONLY) {
+                var stackList = this.internal.getAvailableItems(this.getChannel().createList());
+                for (final T t : stackList) {
+                    if (this.canExtract(t)) {
+                        out.add(t);
+                    }
+                }
+            } else {
+                return this.internal.getAvailableItems(out);
+            }
+        } finally {
+            this.gettingAvailableContent = false;
+        }
+
+        return out;
     }
 
     @Override
@@ -136,13 +155,11 @@ public class MEInventoryHandler<T extends IAEStack<T>> implements IMEInventoryHa
             return false;
         }
 
-        if (this.myWhitelist == IncludeExclude.BLACKLIST && this.myPartitionList.isListed(input)) {
+        if (!this.passesBlackOrWhitelist(input)) {
             return false;
         }
-        if (this.myPartitionList.isEmpty() || this.myWhitelist == IncludeExclude.BLACKLIST) {
-            return this.internal.canAccept(input);
-        }
-        return this.myPartitionList.isListed(input) && this.internal.canAccept(input);
+
+        return this.internal.canAccept(input);
     }
 
     @Override
@@ -175,5 +192,28 @@ public class MEInventoryHandler<T extends IAEStack<T>> implements IMEInventoryHa
 
     public void setSticky(boolean isSticky) {
         this.isSticky = isSticky;
+    }
+
+    protected boolean canExtract(T request) {
+        return this.hasReadAccess && passesBlackOrWhitelist(request);
+    }
+
+    public boolean passesBlackOrWhitelist(T input) {
+        if (this.myPartitionList.isEmpty()) {
+            return true;
+        }
+
+        return switch (this.myWhitelist) {
+            case WHITELIST -> this.myPartitionList.isListed(input);
+            case BLACKLIST -> !this.myPartitionList.isListed(input);
+        };
+    }
+
+    public StorageFilter getStorageFilter() {
+        return storageFilter;
+    }
+
+    public void setStorageFilter(StorageFilter storageFilter) {
+        this.storageFilter = storageFilter;
     }
 }

--- a/src/main/java/appeng/parts/misc/PartOreDicStorageBus.java
+++ b/src/main/java/appeng/parts/misc/PartOreDicStorageBus.java
@@ -111,8 +111,8 @@ public class PartOreDicStorageBus extends PartStorageBus {
                 this.handler.setBaseAccess((AccessRestriction) this.getConfigManager().getSetting(Settings.ACCESS));
                 this.handler.setWhitelist(this.getInstalledUpgrades(Upgrades.INVERTER) > 0 ? IncludeExclude.BLACKLIST : IncludeExclude.WHITELIST);
                 this.handler.setPriority(this.priority);
-
                 this.handler.setPartitionList(this.getPriorityList());
+                this.handler.setStorageFilter((StorageFilter) this.getConfigManager().getSetting(Settings.STORAGE_FILTER));
 
                 if (inv instanceof IBaseMonitor) {
                     if (((AccessRestriction) ((ConfigManager) this.getConfigManager()).getSetting(Settings.ACCESS)).hasPermission(AccessRestriction.READ)) {


### PR DESCRIPTION
Small scope fix of a bigger problem:
* Fixes stacks being reported despite not passing the filter
  * Fixes aforementioned stacks being extractable
* Fixes "report inaccessible items" reporting stacks anyway in certain situations

As a footnote, optimally, this should all be reworked to closely mirror https://github.com/AppliedEnergistics/Applied-Energistics-2/pull/5614 and/or [insert relevant GTNH AE2 PR]. The current ME Storage Bus code is built on crutches upon crutches held together with years of duct tape. Some of the common methods are identical all over the place, with differences that are pretty much irrelevant.