### PR TITLE
Use LoadingCache instead of HashMap for CableBusBakedModel

### DIFF
--- a/src/main/java/appeng/client/render/cablebus/CableBusModel.java
+++ b/src/main/java/appeng/client/render/cablebus/CableBusModel.java
@@ -27,26 +27,21 @@ import com.google.common.collect.ImmutableMap;
 import net.minecraft.client.renderer.block.model.IBakedModel;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.vertex.VertexFormat;
-import net.minecraft.client.resources.IResourceManager;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.IModel;
 import net.minecraftforge.client.model.ModelLoaderRegistry;
-import net.minecraftforge.client.resource.IResourceType;
-import net.minecraftforge.client.resource.ISelectiveResourceReloadListener;
-import net.minecraftforge.client.resource.VanillaResourceType;
 import net.minecraftforge.common.model.IModelState;
 import net.minecraftforge.common.model.TRSRTransformation;
 
 import java.util.Collection;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.function.Predicate;
 
 
 /**
  * The built-in model for the cable bus block.
  */
-public class CableBusModel implements IModel, ISelectiveResourceReloadListener {
+public class CableBusModel implements IModel {
 
     private final PartModels partModels;
 
@@ -106,12 +101,4 @@ public class CableBusModel implements IModel, ISelectiveResourceReloadListener {
     public IModelState getDefaultState() {
         return TRSRTransformation.identity();
     }
-
-    @Override
-    public void onResourceManagerReload(IResourceManager resourceManager, Predicate<IResourceType> resourcePredicate) {
-        if (resourcePredicate.test(VanillaResourceType.MODELS)) {
-            CableBusBakedModel.CABLE_MODEL_CACHE.clear();
-        }
-    }
-
 }


### PR DESCRIPTION
Supersedes #362

Uses a cache instead of a hashmap to avoid a CME in java 9+.

New impl in this PR vs #362 implements the cache non-statically, since the baked model is only baked once, and allows us to use a LoadingCache instead of a standard cache, giving us access to getUnchecked(). Additionally this no longer necessitates a resource reload listener, since the model will be automatically rebaked on a resource reload, letting GC clean up the old cache instead of needing to clear it on reload