### PR TITLE
Recache OreDict Buses on RegEx changes & adjust visibility logic

### DIFF
--- a/src/main/java/appeng/me/storage/MEInventoryHandler.java
+++ b/src/main/java/appeng/me/storage/MEInventoryHandler.java
@@ -117,7 +117,7 @@ public class MEInventoryHandler<T extends IAEStack<T>> implements IMEInventoryHa
             if (this.storageFilter == StorageFilter.EXTRACTABLE_ONLY) {
                 var stackList = this.internal.getAvailableItems(this.getChannel().createList());
                 for (final T t : stackList) {
-                    if (this.canExtract(t)) {
+                    if (this.shouldItemBeAvailable(t)) {
                         out.add(t);
                     }
                 }
@@ -196,6 +196,10 @@ public class MEInventoryHandler<T extends IAEStack<T>> implements IMEInventoryHa
 
     protected boolean canExtract(T request) {
         return this.hasReadAccess;
+    }
+
+    private boolean shouldItemBeAvailable(T t) {
+        return this.hasReadAccess && this.passesBlackOrWhitelist(t);
     }
 
     public boolean passesBlackOrWhitelist(T input) {

--- a/src/main/java/appeng/parts/misc/PartOreDicStorageBus.java
+++ b/src/main/java/appeng/parts/misc/PartOreDicStorageBus.java
@@ -165,9 +165,7 @@ public class PartOreDicStorageBus extends PartStorageBus {
             this.oreExp = oreMatch;
 
             this.priorityList = new OreDictPriorityList<>(OreHelper.INSTANCE.getMatchingOre(oreExp), oreExp);
-            if (this.handler != null) {
-                handler.setPartitionList(this.priorityList);
-            }
+            this.resetCache(true);
             this.getHost().markForSave();
         }
     }

--- a/src/main/java/appeng/parts/misc/PartStorageBus.java
+++ b/src/main/java/appeng/parts/misc/PartStorageBus.java
@@ -196,7 +196,7 @@ public class PartStorageBus extends PartUpgradeable implements IGridTickable, IC
         return super.getInventoryByName(name);
     }
 
-    private void resetCache(final boolean fullReset) {
+    protected void resetCache(final boolean fullReset) {
         if (this.getHost() == null || this.getHost().getTile() == null || this.getHost().getTile().getWorld() == null || this.getHost().getTile().getWorld().isRemote) {
             return;
         }
@@ -319,7 +319,7 @@ public class PartStorageBus extends PartUpgradeable implements IGridTickable, IC
         return TickRateModulation.SLEEP;
     }
 
-    private void resetCache() {
+    protected void resetCache() {
         final boolean fullReset = this.resetCacheLogic == 2;
         this.resetCacheLogic = 0;
 


### PR DESCRIPTION
Fixes OreDict Storage Buses not reacting to RegEx changes immediately by forcing them to fully recache themselves.

Additionally, tweaks the item availability logic a little to filter extractables only when the list of available items is being formed.

To closely mirror the modern AE2 behavior, a GUI switch should be introduced to optionally filter items on extract. Right now, since Storage Cells also use MEInventoryHandler under the hood, forcing this behavior without a switch slightly breaks them, making currently stored items inaccessible (but visible) if a Cell is partitioned in a way that excludes said items.