### PR TITLE
Fix NPE when posting changes for storage busses

### DIFF
--- a/src/main/java/appeng/fluids/parts/PartFluidStorageBus.java
+++ b/src/main/java/appeng/fluids/parts/PartFluidStorageBus.java
@@ -221,7 +221,7 @@ public class PartFluidStorageBus extends PartUpgradeable implements IGridTickabl
     @Override
     public void postChange(final IBaseMonitor<IAEFluidStack> monitor, final Iterable<IAEFluidStack> change, final IActionSource source) {
         if (this.getProxy().isActive()) {
-            var filteredChanges = this.filterChanges(change);
+            var filteredChanges = this.handler == null ? change : this.filterChanges(change);
 
             AccessRestriction currentAccess = (AccessRestriction) ((ConfigManager) this.getConfigManager()).getSetting(Settings.ACCESS);
             if (readOncePass) {

--- a/src/main/java/appeng/fluids/parts/PartFluidStorageBus.java
+++ b/src/main/java/appeng/fluids/parts/PartFluidStorageBus.java
@@ -221,7 +221,7 @@ public class PartFluidStorageBus extends PartUpgradeable implements IGridTickabl
     @Override
     public void postChange(final IBaseMonitor<IAEFluidStack> monitor, final Iterable<IAEFluidStack> change, final IActionSource source) {
         if (this.getProxy().isActive()) {
-            var filteredChanges = this.handler == null ? change : this.filterChanges(change);
+            var filteredChanges = this.filterChanges(change);
 
             AccessRestriction currentAccess = (AccessRestriction) ((ConfigManager) this.getConfigManager()).getSetting(Settings.ACCESS);
             if (readOncePass) {
@@ -551,7 +551,7 @@ public class PartFluidStorageBus extends PartUpgradeable implements IGridTickabl
      */
     protected Iterable<IAEFluidStack> filterChanges(Iterable<IAEFluidStack> change) {
         var storageFilter = this.getConfigManager().getSetting(Settings.STORAGE_FILTER);
-        if (storageFilter == StorageFilter.EXTRACTABLE_ONLY) {
+        if (storageFilter == StorageFilter.EXTRACTABLE_ONLY && handler != null) {
             var filteredList = new ArrayList<IAEFluidStack>();
             for (final IAEFluidStack stack : change) {
                 if (this.handler.passesBlackOrWhitelist(stack)) {

--- a/src/main/java/appeng/parts/misc/PartStorageBus.java
+++ b/src/main/java/appeng/parts/misc/PartStorageBus.java
@@ -222,7 +222,7 @@ public class PartStorageBus extends PartUpgradeable implements IGridTickable, IC
     @Override
     public void postChange(final IBaseMonitor<IAEItemStack> monitor, final Iterable<IAEItemStack> change, final IActionSource source) {
         if (this.getProxy().isActive()) {
-            var filteredChanges = this.handler == null ? change : this.filterChanges(change);
+            var filteredChanges = this.filterChanges(change);
 
             AccessRestriction currentAccess = (AccessRestriction) ((ConfigManager) this.getConfigManager()).getSetting(Settings.ACCESS);
             if (readOncePass) {
@@ -585,7 +585,7 @@ public class PartStorageBus extends PartUpgradeable implements IGridTickable, IC
      */
     protected Iterable<IAEItemStack> filterChanges(Iterable<IAEItemStack> change) {
         var storageFilter = this.getConfigManager().getSetting(Settings.STORAGE_FILTER);
-        if (storageFilter == StorageFilter.EXTRACTABLE_ONLY) {
+        if (storageFilter == StorageFilter.EXTRACTABLE_ONLY && handler != null) {
             var filteredList = new ArrayList<IAEItemStack>();
             for (final IAEItemStack stack : change) {
                 if (this.handler.passesBlackOrWhitelist(stack)) {

--- a/src/main/java/appeng/parts/misc/PartStorageBus.java
+++ b/src/main/java/appeng/parts/misc/PartStorageBus.java
@@ -222,7 +222,7 @@ public class PartStorageBus extends PartUpgradeable implements IGridTickable, IC
     @Override
     public void postChange(final IBaseMonitor<IAEItemStack> monitor, final Iterable<IAEItemStack> change, final IActionSource source) {
         if (this.getProxy().isActive()) {
-            var filteredChanges = this.filterChanges(change);
+            var filteredChanges = this.handler == null ? change : this.filterChanges(change);
 
             AccessRestriction currentAccess = (AccessRestriction) ((ConfigManager) this.getConfigManager()).getSetting(Settings.ACCESS);
             if (readOncePass) {


### PR DESCRIPTION
Prevents a NPE being thrown when posting changes from removing the connected TE associated with the handler, causing the TE in question it be removed before dropping itself as an item.