### PR TITLE
Fix long non-player initiated automatic crafts

### DIFF
--- a/src/main/java/appeng/crafting/CraftingJob.java
+++ b/src/main/java/appeng/crafting/CraftingJob.java
@@ -202,7 +202,6 @@ public class CraftingJob implements Runnable, ICraftingJob {
             synchronized (this.monitor) {
                 if (this.tickSpreadingWatch.elapsed(TimeUnit.MICROSECONDS) > this.time) {
                     this.running = false;
-                    this.craftingTreeWatch.stop();
                     this.tickSpreadingWatch.stop();
                     this.monitor.notify();
                 }


### PR DESCRIPTION
I was trying to automate AE2 autocrafting with OpenComputers, which I found worked for simple crafts, but failed for larger crafts with the following stack trace:

<details>
<summary>Stack trace</summary>
<pre>
[01:31:43] [ForkJoinPool-1-worker-11/DEBUG] [opencomputers]: Error submitting job to AE2.
java.util.concurrent.ExecutionException: java.lang.IllegalStateException: java.lang.IllegalStateException: This stopwatch is already stopped.
	at java.util.concurrent.FutureTask.report(Unknown Source) ~[?:1.8.0_391]
	at java.util.concurrent.FutureTask.get(Unknown Source) ~[?:1.8.0_391]
	at li.cil.oc.integration.appeng.NetworkControl$Craftable$$anonfun$request$1$$anonfun$apply$1.apply$mcV$sp(NetworkControl.scala:364) [NetworkControl$Craftable$$anonfun$request$1$$anonfun$apply$1.class:?]
	at li.cil.oc.integration.appeng.NetworkControl$Craftable$$anonfun$request$1$$anonfun$apply$1.apply(NetworkControl.scala:359) [NetworkControl$Craftable$$anonfun$request$1$$anonfun$apply$1.class:?]
	at li.cil.oc.integration.appeng.NetworkControl$Craftable$$anonfun$request$1$$anonfun$apply$1.apply(NetworkControl.scala:359) [NetworkControl$Craftable$$anonfun$request$1$$anonfun$apply$1.class:?]
	at scala.concurrent.impl.Future$PromiseCompletingRunnable.liftedTree1$1(Future.scala:24) [scala-library-2.11.1.jar:?]
	at scala.concurrent.impl.Future$PromiseCompletingRunnable.run(Future.scala:24) [scala-library-2.11.1.jar:?]
	at scala.concurrent.impl.ExecutionContextImpl$AdaptedForkJoinTask.exec(ExecutionContextImpl.scala:121) [scala-library-2.11.1.jar:?]
	at scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260) [scala-library-2.11.1.jar:?]
	at scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339) [scala-library-2.11.1.jar:?]
	at scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979) [scala-library-2.11.1.jar:?]
	at scala.concurrent.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107) [scala-library-2.11.1.jar:?]
Caused by: java.lang.IllegalStateException: java.lang.IllegalStateException: This stopwatch is already stopped.
	at appeng.crafting.CraftingJob.run(CraftingJob.java:193) ~[CraftingJob.class:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source) ~[?:1.8.0_391]
	at java.util.concurrent.FutureTask.run(Unknown Source) ~[?:1.8.0_391]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) ~[?:1.8.0_391]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) ~[?:1.8.0_391]
	at java.lang.Thread.run(Unknown Source) ~[?:1.8.0_391]
Caused by: java.lang.IllegalStateException: This stopwatch is already stopped.
	at com.google.common.base.Preconditions.checkState(Preconditions.java:444) ~[guava-21.0.jar:?]
	at com.google.common.base.Stopwatch.stop(Stopwatch.java:159) ~[guava-21.0.jar:?]
	at appeng.crafting.CraftingJob.handlePausing(CraftingJob.java:205) ~[CraftingJob.class:?]
	at appeng.crafting.CraftingTreeProcess.request(CraftingTreeProcess.java:197) ~[CraftingTreeProcess.class:?]
	at appeng.crafting.CraftingTreeNode.request(CraftingTreeNode.java:250) ~[CraftingTreeNode.class:?]
	at appeng.crafting.CraftingTreeProcess.request(CraftingTreeProcess.java:201) ~[CraftingTreeProcess.class:?]
	at appeng.crafting.CraftingTreeNode.request(CraftingTreeNode.java:219) ~[CraftingTreeNode.class:?]
	at appeng.crafting.CraftingTreeProcess.request(CraftingTreeProcess.java:201) ~[CraftingTreeProcess.class:?]
	at appeng.crafting.CraftingTreeNode.request(CraftingTreeNode.java:219) ~[CraftingTreeNode.class:?]
	at appeng.crafting.CraftingJob.run(CraftingJob.java:135) ~[CraftingJob.class:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source) ~[?:1.8.0_391]
	at java.util.concurrent.FutureTask.run(Unknown Source) ~[?:1.8.0_391]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) ~[?:1.8.0_391]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) ~[?:1.8.0_391]
	at java.lang.Thread.run(Unknown Source) ~[?:1.8.0_391]
</pre>
</details>

After staring at the code, this is caused by `this.craftingTreeWatch` being stopped on line 205, without any analogous start, like there is for `this.tickSpreadingWatch`, on lines 284-285. Line 205 only runs for non-player initiated autocrafts, like in this caes, through the API, or through crafting cards. The variable `this.craftingTreeWatch` seems to only be used for debugging purposes, so this line should be completely safe to remove (or the variable altogether).

https://github.com/AE2-UEL/Applied-Energistics-2/blob/90112732292ebe68b57f110b336ccce3d8e5c4aa/src/main/java/appeng/crafting/CraftingJob.java#L205

https://github.com/AE2-UEL/Applied-Energistics-2/blob/90112732292ebe68b57f110b336ccce3d8e5c4aa/src/main/java/appeng/crafting/CraftingJob.java#L284-L285

Removing line 205 fixes the autocrafting for OpenComputers, allowing me to autocraft larger crafts, whereas I couldn't before. Interestingly, I think that this also fixes crafting cards, as crafting cards weren't working for complicated crafts on my world too, but they seem to work after this fix. I guess the reason it hasn't been noticed until now is that the exception gets eaten by some exception handler for crafting cards.

The crafting card issue is very simple to reproduce on my DJ2 world, I would be very surprised if nobody else has hit that issue.