### PR TITLE
Allow non-item slot to lookup recipe in jei

### DIFF
--- a/src/main/java/appeng/client/gui/AEGuiHandler.java
+++ b/src/main/java/appeng/client/gui/AEGuiHandler.java
@@ -72,6 +72,10 @@ public class AEGuiHandler implements IAdvancedGuiHandler<AEBaseGui>, IGhostIngre
             }
         }
 
+        if (result != null) {
+            return result;
+        }
+
         Slot slot = guiContainer.getSlotUnderMouse();
         if (slot instanceof ISpecialSlotIngredient ss) {
             return ss.getIngredient();

--- a/src/main/java/appeng/client/gui/AEGuiHandler.java
+++ b/src/main/java/appeng/client/gui/AEGuiHandler.java
@@ -7,11 +7,15 @@ import appeng.client.gui.implementations.GuiCraftingCPU;
 import appeng.client.gui.implementations.GuiExpandedProcessingPatternTerm;
 import appeng.client.gui.implementations.GuiPatternTerm;
 import appeng.client.gui.implementations.GuiUpgradeable;
+import appeng.client.gui.widgets.GuiCustomSlot;
 import appeng.container.interfaces.IJEIGhostIngredients;
+import appeng.container.interfaces.ISpecialSlotIngredient;
 import appeng.container.slot.IJEITargetSlot;
 import mezz.jei.api.gui.IAdvancedGuiHandler;
 import mezz.jei.api.gui.IGhostIngredientHandler;
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.inventory.Slot;
 import org.lwjgl.input.Mouse;
 
 import javax.annotation.Nonnull;
@@ -63,9 +67,33 @@ public class AEGuiHandler implements IAdvancedGuiHandler<AEBaseGui>, IGhostIngre
         if (guiContainer instanceof GuiCraftAmount) {
             if (guiContainer.getSlotUnderMouse() != null) {
                 result = guiContainer.getSlotUnderMouse().getStack();
+            } else {
+                return null;
             }
         }
+
+        Slot slot = guiContainer.getSlotUnderMouse();
+        if (slot instanceof ISpecialSlotIngredient ss) {
+            return ss.getIngredient();
+        }
+        for (GuiCustomSlot customSlot : guiContainer.guiSlots) {
+            if (this.checkSlotArea(guiContainer, customSlot, mouseX, mouseY)) {
+                return customSlot.getIngredient();
+            }
+        }
+
         return result;
+    }
+
+    private boolean checkSlotArea(GuiContainer gui, GuiCustomSlot slot, int mouseX, int mouseY) {
+        int i = gui.guiLeft;
+        int j = gui.guiTop;
+        mouseX = mouseX - i;
+        mouseY = mouseY - j;
+        return mouseX >= slot.xPos() - 1 &&
+                mouseX < slot.xPos() + slot.getWidth() + 1 &&
+                mouseY >= slot.yPos() - 1 &&
+                mouseY < slot.yPos() + slot.getHeight() + 1;
     }
 
     private int getSlotidx(AEBaseGui guiContainer, int mouseX, int mouseY, int rows) {

--- a/src/main/java/appeng/client/gui/widgets/GuiCustomSlot.java
+++ b/src/main/java/appeng/client/gui/widgets/GuiCustomSlot.java
@@ -1,13 +1,14 @@
 package appeng.client.gui.widgets;
 
 
+import appeng.container.interfaces.ISpecialSlotIngredient;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 
 
-public abstract class GuiCustomSlot extends Gui implements ITooltip {
+public abstract class GuiCustomSlot extends Gui implements ITooltip, ISpecialSlotIngredient {
     protected final int x;
     protected final int y;
     protected final int id;
@@ -66,6 +67,11 @@ public abstract class GuiCustomSlot extends Gui implements ITooltip {
 
     public boolean isSlotEnabled() {
         return true;
+    }
+
+    @Override
+    public Object getIngredient() {
+        return null;
     }
 
 }

--- a/src/main/java/appeng/client/me/SlotFluidME.java
+++ b/src/main/java/appeng/client/me/SlotFluidME.java
@@ -20,11 +20,13 @@ package appeng.client.me;
 
 
 import appeng.api.storage.data.IAEFluidStack;
+import appeng.container.interfaces.ISpecialSlotIngredient;
 import appeng.fluids.container.slots.IMEFluidSlot;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.items.SlotItemHandler;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.Nonnull;
 
@@ -34,7 +36,7 @@ import javax.annotation.Nonnull;
  * @version rv6 - 22/05/2018
  * @since rv6 22/05/2018
  */
-public class SlotFluidME extends SlotItemHandler implements IMEFluidSlot {
+public class SlotFluidME extends SlotItemHandler implements IMEFluidSlot, ISpecialSlotIngredient {
 
     private final InternalFluidSlotME slot;
 
@@ -95,4 +97,11 @@ public class SlotFluidME extends SlotItemHandler implements IMEFluidSlot {
     public boolean canTakeStack(final EntityPlayer par1EntityPlayer) {
         return false;
     }
+
+    @Nullable
+    @Override
+    public Object getIngredient() {
+        return this.getAEFluidStack() == null ? null : this.getAEFluidStack().getFluidStack();
+    }
+
 }

--- a/src/main/java/appeng/container/interfaces/ISpecialSlotIngredient.java
+++ b/src/main/java/appeng/container/interfaces/ISpecialSlotIngredient.java
@@ -1,0 +1,10 @@
+package appeng.container.interfaces;
+
+import javax.annotation.Nullable;
+
+public interface ISpecialSlotIngredient {
+
+    @Nullable
+    Object getIngredient();
+
+}

--- a/src/main/java/appeng/fluids/client/gui/widgets/GuiFluidSlot.java
+++ b/src/main/java/appeng/fluids/client/gui/widgets/GuiFluidSlot.java
@@ -99,4 +99,9 @@ public class GuiFluidSlot extends GuiCustomSlot implements IJEITargetSlot {
         return this.getFluidStack() == null;
     }
 
+    @Override
+    public Object getIngredient() {
+        return this.getFluidStack() == null ? null : this.getFluidStack().getFluidStack();
+    }
+
 }

--- a/src/main/java/appeng/fluids/client/gui/widgets/GuiFluidTank.java
+++ b/src/main/java/appeng/fluids/client/gui/widgets/GuiFluidTank.java
@@ -147,4 +147,9 @@ public class GuiFluidTank extends GuiCustomSlot implements ITooltip {
         }
     }
 
+    @Override
+    public Object getIngredient() {
+        return this.getFluidStack() == null ? null : this.getFluidStack().getFluidStack();
+    }
+
 }


### PR DESCRIPTION
Now you can use U/R on fluid slot to lookup recipes
![1](https://github.com/AE2-UEL/Applied-Energistics-2/assets/60341015/2be7c6eb-760a-4a8f-9e0c-aae6a7c8b215)
