### PR TITLE
Fix some MouseTweaks interactions

### DIFF
--- a/src/main/java/appeng/client/gui/AEBaseGui.java
+++ b/src/main/java/appeng/client/gui/AEBaseGui.java
@@ -44,6 +44,7 @@ import appeng.util.Platform;
 import appeng.util.item.AEItemStack;
 import com.google.common.base.Joiner;
 import com.google.common.base.Stopwatch;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import mezz.jei.api.gui.IGhostIngredientHandler;
 import net.minecraft.client.Minecraft;
@@ -1057,7 +1058,7 @@ public abstract class AEBaseGui extends GuiContainer implements IMTModGuiContain
     @Override
     @Optional.Method(modid = "mousetweaks")
     public boolean MT_isMouseTweaksDisabled() {
-        return true;
+        return false;
     }
 
     @Override
@@ -1087,12 +1088,20 @@ public abstract class AEBaseGui extends GuiContainer implements IMTModGuiContain
     @Override
     @Optional.Method(modid = "mousetweaks")
     public boolean MT_isIgnored(Slot slot) {
-        return true;
+        return false;
     }
 
     @Override
     @Optional.Method(modid = "mousetweaks")
     public boolean MT_disableRMBDraggingFunctionality() {
-        return true;
+       if (this.dragSplitting && this.dragSplittingButton == 1) {
+           this.dragSplitting = false;
+           // Don't ignoreMouseUp on slots that can't accept the item. (crafting output, ME slot, etc.)
+           if (this.getSlotUnderMouse() != null && this.getSlotUnderMouse().isItemValid(this.mc.player.inventory.getItemStack())) {
+               this.ignoreMouseUp = true;
+           }
+           return true;
+       }
+       return false;
     }
 }

--- a/src/main/java/appeng/client/gui/AEBaseGui.java
+++ b/src/main/java/appeng/client/gui/AEBaseGui.java
@@ -44,7 +44,6 @@ import appeng.util.Platform;
 import appeng.util.item.AEItemStack;
 import com.google.common.base.Joiner;
 import com.google.common.base.Stopwatch;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import mezz.jei.api.gui.IGhostIngredientHandler;
 import net.minecraft.client.Minecraft;

--- a/src/main/resources/appliedenergistics2_at.cfg
+++ b/src/main/resources/appliedenergistics2_at.cfg
@@ -1,3 +1,6 @@
 # GUI rendering
 public net.minecraft.client.gui.inventory.GuiContainer func_146977_a(Lnet/minecraft/inventory/Slot;)V # drawSlot
+public net.minecraft.client.gui.inventory.GuiContainer field_146988_G # dragSplittingButton
+public net.minecraft.client.gui.inventory.GuiContainer field_146987_F # dragSplittingLimit
+public net.minecraft.client.gui.inventory.GuiContainer field_146995_H # ignoreMouseUp
 public net.minecraft.client.gui.GuiTextField func_146188_c(IIII)V # drawSelectionBox


### PR DESCRIPTION
There were a couple bugs from #398, this fixes the MouseTweaks interactions so that they *should* have their intended behavior. That PR introduced a crash when trying to left-click to distribute items over slots that already had the item. Enables MouseTweaks on all slots with special right click handling, fixing the following:
- "Partial stack pickup": This refers to trying to right-click to take a full stack from the crafting output when the cursor is already holding some quantity of the item.
- Drag splitting: The usual hold and drag right/left-click to split a stack over slots.
- Mass transfer: Lef-click dragging over slots while holding shift to transfer items from inventory to ME system.

I would appreciate a test from @FakeDomi to confirm this PR fixes the bugs that were mentioned in #398 (although I have tested this myself and the above 3 mentioned interactions work as intended).
I don't know why I need to add the 3 fields to the access transformer, because I thought they were already public, but they need to be there or the MouseTweaks interactions will cause a crash with `java.lang.IllegalAccessError`.