### PR TITLE
Storage monitor gas support

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -43,6 +43,8 @@ dependencies {
     compileOnly "curse.maven:inventory-bogo-sorter-632327:4399738"
     compileOnly rfg.deobf("curse.maven:ctm-267602:2915363") // CTM 1.0.2.31
     compileOnly rfg.deobf("curse.maven:actually-additions-228404:3117927") // ActuallyAdditions r152
+    compileOnly rfg.deobf("curse.maven:mekanism-energistics-1027681:5408319") // Mekanism Energistics 0.1.4
+    compileOnly rfg.deobf("curse.maven:mekanism-ce-399904:5351260") // Mekanism-CE 9.12.10
 }
 
 minecraft {

--- a/src/main/java/appeng/client/render/TesrRenderHelper.java
+++ b/src/main/java/appeng/client/render/TesrRenderHelper.java
@@ -23,6 +23,8 @@ import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.util.IWideReadableNumberConverter;
 import appeng.util.ReadableNumberConverter;
+import com.mekeng.github.common.me.data.IAEGasStack;
+import mekanism.api.gas.GasStack;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.*;
@@ -196,6 +198,59 @@ public class TesrRenderHelper {
         GlStateManager.translate(-0.5f * width, 0.0f, 0.5f);
         fr.drawString(renderedStackSize, 0, 0, 0);
 
+    }
+
+    public static void renderGas2d(GasStack gasStack, float scale) {
+        if (gasStack != null) {
+            GlStateManager.pushMatrix();
+            int color = gasStack.getGas().getTint();
+            float r = (float)(color >> 16 & 255) / 255.0F;
+            float g = (float)(color >> 8 & 255) / 255.0F;
+            float b = (float)(color & 255) / 255.0F;
+            TextureAtlasSprite sprite = gasStack.getGas().getSprite();
+            GlStateManager.enableBlend();
+            GlStateManager.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
+            GlStateManager.disableAlpha();
+            GlStateManager.disableLighting();
+            Minecraft.getMinecraft().getTextureManager().bindTexture(TextureMap.LOCATION_BLOCKS_TEXTURE);
+            Tessellator tess = Tessellator.getInstance();
+            BufferBuilder buf = tess.getBuffer();
+            float width = 0.4F;
+            float height = 0.4F;
+            float alpha = 1.0F;
+            float z = 1.0E-4F;
+            float x = -0.2F;
+            float y = -0.25F;
+            buf.begin(7, DefaultVertexFormats.POSITION_TEX_COLOR);
+            double uMin = (double)sprite.getInterpolatedU(16.0 - (double)width * 16.0);
+            double uMax = (double)sprite.getInterpolatedU((double)width * 16.0);
+            double vMin = (double)sprite.getMinV();
+            double vMax = (double)sprite.getInterpolatedV((double)height * 16.0);
+            buf.pos((double)x, (double)y, (double)z).tex(uMin, vMin).color(r, g, b, alpha).endVertex();
+            buf.pos((double)x, (double)(y + height), (double)z).tex(uMin, vMax).color(r, g, b, alpha).endVertex();
+            buf.pos((double)(x + width), (double)(y + height), (double)z).tex(uMax, vMax).color(r, g, b, alpha).endVertex();
+            buf.pos((double)(x + width), (double)y, (double)z).tex(uMax, vMin).color(r, g, b, alpha).endVertex();
+            tess.draw();
+            GlStateManager.enableLighting();
+            GlStateManager.enableAlpha();
+            GlStateManager.disableBlend();
+            GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+            GlStateManager.popMatrix();
+        }
+
+    }
+
+    public static void renderGas2dWithAmount(IAEGasStack gasStack, float scale, float spacing) {
+        GasStack renderStack = gasStack.getGasStack();
+        renderGas2d(renderStack, scale);
+        long stackSize = gasStack.getStackSize() / 1000L;
+        String renderedStackSize = NUMBER_CONVERTER.toWideReadableForm(stackSize) + "B";
+        FontRenderer fr = Minecraft.getMinecraft().fontRenderer;
+        int width = fr.getStringWidth(renderedStackSize);
+        GlStateManager.translate(0.0F, spacing, 0.0F);
+        GlStateManager.scale(0.016129032F, 0.016129032F, 0.016129032F);
+        GlStateManager.translate(-0.5F * (float)width, 0.0F, 0.5F);
+        fr.drawString(renderedStackSize, 0, 0, 0);
     }
 
 }

--- a/src/main/java/appeng/integration/modules/waila/part/StorageMonitorWailaDataProvider.java
+++ b/src/main/java/appeng/integration/modules/waila/part/StorageMonitorWailaDataProvider.java
@@ -25,6 +25,8 @@ import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IAEStack;
 import appeng.core.localization.WailaText;
+import appeng.util.Platform;
+import com.mekeng.github.common.me.data.IAEGasStack;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 
@@ -64,6 +66,12 @@ public final class StorageMonitorWailaDataProvider extends BasePartWailaDataProv
             } else if (displayed instanceof IAEFluidStack) {
                 final IAEFluidStack ais = (IAEFluidStack) displayed;
                 currentToolTip.add(WailaText.Showing.getLocal() + ": " + ais.getFluid().getLocalizedName(ais.getFluidStack()));
+            }
+
+            if (Platform.isModLoaded("mekeng")){
+                if (displayed instanceof IAEGasStack ais){
+                    currentToolTip.add(WailaText.Showing.getLocal() + ": " + ais.getGas().getLocalizedName());
+                }
             }
 
             currentToolTip.add((isLocked) ? WailaText.Locked.getLocal() : WailaText.Unlocked.getLocal());

--- a/src/main/java/appeng/parts/reporting/PartConversionMonitor.java
+++ b/src/main/java/appeng/parts/reporting/PartConversionMonitor.java
@@ -39,6 +39,12 @@ import appeng.parts.PartModel;
 import appeng.util.InventoryAdaptor;
 import appeng.util.Platform;
 import appeng.util.item.AEItemStack;
+import com.mekeng.github.common.me.data.IAEGasStack;
+import com.mekeng.github.common.me.data.impl.AEGasStack;
+import com.mekeng.github.common.me.storage.IGasStorageChannel;
+import com.mekeng.github.util.Utils;
+import com.mekeng.github.util.helpers.ItemGasHandler;
+import mekanism.api.gas.GasStack;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -95,6 +101,7 @@ public class PartConversionMonitor extends AbstractPartMonitor {
 
         final ItemStack eq = player.getHeldItem(hand);
         FluidStack fluidInTank = null;
+        Object gasInTank = null;
         if (eq.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)) {
             IFluidHandlerItem fluidHandlerItem = (eq.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null));
             fluidInTank = fluidHandlerItem.drain(Integer.MAX_VALUE, false);
@@ -110,6 +117,16 @@ public class PartConversionMonitor extends AbstractPartMonitor {
                 if (this.getDisplayed() != null && getDisplayed().equals(AEFluidStack.fromFluidStack(fluidInTank))) {
                     this.drainFluidContainer(player, hand);
                 }
+            } else if (Platform.isModLoaded("mekeng")) {
+                ItemGasHandler itemGasHandler = Utils.getItemGasHandler(eq);
+                if (itemGasHandler != null) {
+                    gasInTank = itemGasHandler.removeGas(Integer.MAX_VALUE, false);
+                    if (gasInTank != null && ((GasStack) gasInTank).amount > 0) {
+                        if (this.getDisplayed() != null && this.getDisplayed().equals(AEGasStack.of(((GasStack) gasInTank)))) {
+                            this.drainGasContainer(player, hand);
+                        }
+                    }
+                }
             } else {
                 this.insertItem(player, hand, false);
             }
@@ -122,6 +139,15 @@ public class PartConversionMonitor extends AbstractPartMonitor {
                 return super.onPartActivate(player, hand, pos);
             }
             if (((IAEFluidStack) this.getDisplayed()).equals(AEFluidStack.fromFluidStack(fluidInTank))) {
+                this.drainFluidContainer(player, hand);
+            } else {
+                return super.onPartActivate(player, hand, pos);
+            }
+        } else if (Platform.isModLoaded("mekeng") && gasInTank != null && ((GasStack) gasInTank).amount > 0) {
+            if (getDisplayed() instanceof IAEItemStack || getDisplayed() == null) {
+                return super.onPartActivate(player, hand, pos);
+            }
+            if (((IAEGasStack) this.getDisplayed()).equals(AEFluidStack.fromFluidStack(fluidInTank))) {
                 this.drainFluidContainer(player, hand);
             } else {
                 return super.onPartActivate(player, hand, pos);
@@ -150,6 +176,10 @@ public class PartConversionMonitor extends AbstractPartMonitor {
             this.extractItem(player, ((IAEItemStack) this.getDisplayed()).getDefinition().getMaxStackSize());
         } else if (this.getDisplayed() != null && this.getDisplayed() instanceof IAEFluidStack) {
             this.fillFluidContainer(player, hand);
+        }
+
+        if (Platform.isModLoaded("mekeng") && this.getDisplayed() != null && this.getDisplayed() instanceof IAEGasStack) {
+            this.fillGasContainer(player, hand);
         }
 
         return true;
@@ -360,6 +390,120 @@ public class PartConversionMonitor extends AbstractPartMonitor {
                 AELog.error("Fluid item [%s] reported a different possible amount than it actually accepted.", held.getDisplayName());
             }
             player.setHeldItem(hand, fh.getContainer());
+        } catch (GridAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void drainGasContainer(final EntityPlayer player, final EnumHand hand) {
+        try {
+            final ItemStack held = player.getHeldItem(hand);
+            if (held.getCount() != 1) {
+                // only support stacksize 1 for now
+                return;
+            }
+
+            final ItemGasHandler itemGasHandler = Utils.getItemGasHandler(held);
+            if (itemGasHandler == null) {
+                // only gas handlers items
+                return;
+            }
+
+            // See how much we can drain from the item
+            final GasStack extract = itemGasHandler.removeGas(Integer.MAX_VALUE, false);
+            if (extract == null || extract.amount < 1) {
+                return;
+            }
+
+            // Check if we can push into the system
+            final IEnergySource energy = this.getProxy().getEnergy();
+            final IMEMonitor<IAEGasStack> cell = this.getProxy()
+                    .getStorage()
+                    .getInventory(
+                            AEApi.instance().storage().getStorageChannel(IGasStorageChannel.class));
+            final IAEGasStack notStorable = Platform.poweredInsert(energy, cell, AEGasStack.of(extract), new PlayerSource(player, this), Actionable.SIMULATE);
+
+            if (notStorable != null && notStorable.getStackSize() > 0) {
+                final int toStore = (int) (extract.amount - notStorable.getStackSize());
+                final GasStack storable = itemGasHandler.removeGas(toStore, false);
+
+                if (storable == null || storable.amount == 0) {
+                    return;
+                } else {
+                    extract.amount = storable.amount;
+                }
+            }
+
+            // Actually drain
+            final GasStack drained = itemGasHandler.removeGas(extract, true);
+            extract.amount = drained.amount;
+
+            final IAEGasStack notInserted = Platform.poweredInsert(energy, cell, AEGasStack.of(extract), new PlayerSource(player, this));
+
+            if (notInserted != null && notInserted.getStackSize() > 0) {
+                AELog.error("Fluid item [%s] reported a different possible amount to drain than it actually provided.", held.getDisplayName());
+            }
+
+            player.setHeldItem(hand, itemGasHandler.getContainer());
+        } catch (GridAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void fillGasContainer(final EntityPlayer player, final EnumHand hand) {
+        try {
+            final ItemStack held = player.getHeldItem(hand);
+            if (held.getCount() != 1) {
+                // only support stacksize 1 for now
+                return;
+            }
+
+            final ItemGasHandler itemGasHandler = Utils.getItemGasHandler(held);
+            if (itemGasHandler == null) {
+                // only gas handlers items
+                return;
+            }
+
+            final IAEGasStack stack = (IAEGasStack) this.getDisplayed().copy();
+
+            // Check how much we can store in the item
+            stack.setStackSize(Integer.MAX_VALUE);
+            int amountAllowed = itemGasHandler.addGas(stack.getGasStack(), false);
+            stack.setStackSize(amountAllowed);
+
+            // Check if we can pull out of the system
+            final IEnergySource energy = this.getProxy().getEnergy();
+            final IMEMonitor<IAEGasStack> cell = this.getProxy()
+                    .getStorage()
+                    .getInventory(
+                            AEApi.instance().storage().getStorageChannel(IGasStorageChannel.class));
+            final IAEGasStack canPull = Platform.poweredExtraction(energy, cell, stack, new PlayerSource(player, this), Actionable.SIMULATE);
+            if (canPull == null || canPull.getStackSize() < 1) {
+                return;
+            }
+
+            // How much could fit into the container
+            final int canFill = itemGasHandler.addGas(canPull.getGasStack(), false);
+            if (canFill == 0) {
+                return;
+            }
+
+            // Now actually pull out of the system
+            stack.setStackSize(canFill);
+            final IAEGasStack pulled = Platform.poweredExtraction(energy, cell, stack, new PlayerSource(player, this));
+            if (pulled == null || pulled.getStackSize() < 1) {
+                // Something went wrong
+                AELog.error("Unable to pull fluid out of the ME system even though the simulation said yes ");
+                return;
+            }
+
+            // Actually fill
+            final int used = itemGasHandler.addGas(pulled.getGasStack(), true);
+
+            if (used != canFill) {
+                AELog.error("Fluid item [%s] reported a different possible amount than it actually accepted.", held.getDisplayName());
+            }
+            player.setHeldItem(hand, itemGasHandler.getContainer());
         } catch (GridAccessException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Added support for IAEGasStack and GasStack for the Storage Monitor and its conversion type, when Mekanism Energistics is loaded

I personally think this design is terrible. I think we can consider combined the configuredItem and configuredFluid  
 into a List<IAEStack> and operate on each object in a for loop to make the implementation more human-friendly.

@NotMyWing What do you think?