### PR TITLE
Fix nullable inscriber inputs

### DIFF
--- a/src/main/java/appeng/core/features/registries/inscriber/InscriberRecipe.java
+++ b/src/main/java/appeng/core/features/registries/inscriber/InscriberRecipe.java
@@ -27,6 +27,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 
@@ -58,8 +59,8 @@ public class InscriberRecipe implements IInscriberRecipe {
         this.inputs.addAll(inputs);
 
         this.output = output;
-        this.maybeTop = top;
-        this.maybeBot = bot;
+        this.maybeTop = top == null || top.isEmpty() ? Collections.emptyList() : top;
+        this.maybeBot = bot == null || bot.isEmpty() ? Collections.emptyList() : bot;
 
         this.type = type;
     }
@@ -129,6 +130,4 @@ public class InscriberRecipe implements IInscriberRecipe {
         result = 31 * result + this.type.hashCode();
         return result;
     }
-
-
 }


### PR DESCRIPTION
Before #430 the top and bottom input was an optional. The fields were never null. After that pr its no longer optional and the fields can be null, but the fields are still annotated with `@Nonnull` and the rest of class still assumes that it isn't null.
(I did saw crash log were that happened, but i cant find it right now)
This pr simply sets the top and bottom input to an empty list if its null.