### PR TITLE
Update action build script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -12,8 +12,10 @@ jobs:
         with:
           java-version: '17'
           distribution: 'adopt' # You can choose other OpenJDK distributions.
+      - name: Update Build Script (Before Build)
+        run: ./gradlew updateBuildScript
       - name: Build with Gradle
-        run: ./gradlew build # Ensure your gradlew script is executable
+        run: ./gradlew build
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up OpenJDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt' # You can choose other OpenJDK distributions.
@@ -17,7 +17,7 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: AE2-UEL
           path: build/libs/*.jar # Make sure this path matches the location of your build artifacts


### PR DESCRIPTION
~~Add support for PR~~ and fix a compatibility bug

The existing build has an invalid version number, which will cause mods that depend on AE2 to report errors when loading. Executing the "updateBuildScript" task in advance can solve this problem

