### PR TITLE
Make `FluidHandlerAdapter` Cache Properly use Tank Properties

### DIFF
--- a/src/main/java/appeng/fluids/parts/FluidHandlerAdapter.java
+++ b/src/main/java/appeng/fluids/parts/FluidHandlerAdapter.java
@@ -194,10 +194,11 @@ public class FluidHandlerAdapter implements IMEInventory<IAEFluidStack>, IBaseMo
             IItemList<IAEFluidStack> currentlyOnStorage = AEApi.instance().storage().getStorageChannel(IFluidStorageChannel.class).createList();
 
             for (IFluidTankProperties tankProperty : tankProperties) {
-                if (this.mode == StorageFilter.EXTRACTABLE_ONLY && this.fluidHandler.drain(1, false) == null) {
+                var contents = tankProperty.getContents();
+                if (this.mode == StorageFilter.EXTRACTABLE_ONLY && !tankProperty.canDrainFluidType(contents)) {
                     continue;
                 }
-                currentlyOnStorage.add(AEFluidStack.fromFluidStack(tankProperty.getContents()));
+                currentlyOnStorage.add(AEFluidStack.fromFluidStack(contents));
             }
 
             for (final IAEFluidStack is : currentlyCached) {

--- a/src/main/java/appeng/fluids/parts/FluidHandlerAdapter.java
+++ b/src/main/java/appeng/fluids/parts/FluidHandlerAdapter.java
@@ -195,7 +195,7 @@ public class FluidHandlerAdapter implements IMEInventory<IAEFluidStack>, IBaseMo
 
             for (IFluidTankProperties tankProperty : tankProperties) {
                 var contents = tankProperty.getContents();
-                if (this.mode == StorageFilter.EXTRACTABLE_ONLY && !tankProperty.canDrainFluidType(contents)) {
+                if (this.mode == StorageFilter.EXTRACTABLE_ONLY && this.fluidHandler.drain(contents, false) == null) {
                     continue;
                 }
                 currentlyOnStorage.add(AEFluidStack.fromFluidStack(contents));


### PR DESCRIPTION
the cache makes the assumption that the fluid handler has exactly one tank, causing issues if the handler has multiple internal tanks to choose from (as it can always pick the same tank for different properties). i've replaced the drain call with the appropriate method from tank property, which should better handle all cases for a fluid handler.