### PR TITLE
Fix interface terminal localization

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
@@ -69,7 +69,7 @@ public class GuiInterfaceTerminal extends AEBaseGui {
 
     private static final int OFFSET_X = 21;
     private static final int MAGIC_HEIGHT_NUMBER = 52 + 99;
-    private static final String MOLECULAR_ASSEMBLER = "molecular assembler";
+    private static final String MOLECULAR_ASSEMBLER = "tile.appliedenergistics2.molecular_assembler";
 
     private final boolean jeiEnabled;
     private final int jeiButtonPadding;
@@ -536,7 +536,8 @@ public class GuiInterfaceTerminal extends AEBaseGui {
                 continue;
             }
             // Exit if molecular assembler filter is on and this is not a molecular assembler
-            if (onlyMolecularAssemblers && !entry.getName().toLowerCase().contains(MOLECULAR_ASSEMBLER)) {
+            // Forge documantation said unlocalized name shouldn't be use for logic, so we might need a better way......
+            if (onlyMolecularAssemblers && !entry.getUnlocalizedName().equals(MOLECULAR_ASSEMBLER)) {
                 cachedSearch.remove(entry);
                 continue;
             }

--- a/src/main/java/appeng/client/me/ClientDCInternalInv.java
+++ b/src/main/java/appeng/client/me/ClientDCInternalInv.java
@@ -55,6 +55,10 @@ public class ClientDCInternalInv implements Comparable<ClientDCInternalInv> {
         return s;
     }
 
+    public String getUnlocalizedName() {
+        return this.unlocalizedName;
+    }
+
     @Override
     public int compareTo(@Nonnull final ClientDCInternalInv o) {
         return Long.compare(this.sortBy, o.sortBy);

--- a/src/main/java/appeng/helpers/DualityInterface.java
+++ b/src/main/java/appeng/helpers/DualityInterface.java
@@ -1455,7 +1455,7 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
                 }
 
                 if (what.getItem() != Items.AIR) {
-                    return what.getItem().getItemStackDisplayName(what);
+                    return what.getItem().getTranslationKey(what);
                 }
 
                 final Item item = Item.getItemFromBlock(directedBlock);

--- a/src/main/java/appeng/helpers/DualityInterface.java
+++ b/src/main/java/appeng/helpers/DualityInterface.java
@@ -1455,11 +1455,20 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
                 }
 
                 if (what.getItem() != Items.AIR) {
-                    /* If use getTranslationKey(), it will return incomplete translationKey sometimes.
-                     * Such as small item output of a formed machine in mod Modular Machinery Community Edition.
-                     * getTranslationKey() returns tile.modularmachinery.blockinputbus
-                     * getUnlocalizedNameInefficiently() return tile.modularmachinery.blockinputbus.small
-                     * I don't know why they return different result.
+                    /* FIX ME:
+                     * getTranslationKey() and getUnlocalizedNameInefficiently() have different return values in some mod 
+                     *
+                     * For small item output of a formed machine in mod Modular Machinery Community Edition.
+                     * getTranslationKey() returns "tile.modularmachinery.blockinputbus"
+                     * getUnlocalizedNameInefficiently() return "tile.modularmachinery.blockinputbus.small"
+                     * Because modular machinery community edition overides getUnlocalizedNameInefficiently()
+                     * 
+                     * For the Thermal Expansion
+                     * getTranslationKey() returns complete key ending with ".name".
+                     * getUnlocalizedNameInefficiently() returns localized name
+                     * Because CoFH Core overrides method getTranslationKey()
+                     * 
+                     * So is code is invalid to Thermal Expansion.
                      */
                     return what.getItem().getUnlocalizedNameInefficiently(what);
                 }

--- a/src/main/java/appeng/helpers/DualityInterface.java
+++ b/src/main/java/appeng/helpers/DualityInterface.java
@@ -1455,7 +1455,13 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
                 }
 
                 if (what.getItem() != Items.AIR) {
-                    return what.getItem().getTranslationKey(what);
+                    /* If use getTranslationKey(), it will return incomplete translationKey sometimes.
+                     * Such as small item output of a formed machine in mod Modular Machinery Community Edition.
+                     * getTranslationKey() returns tile.modularmachinery.blockinputbus
+                     * getUnlocalizedNameInefficiently() return tile.modularmachinery.blockinputbus.small
+                     * I don't know why they return different result.
+                     */
+                    return what.getItem().getUnlocalizedNameInefficiently(what);
                 }
 
                 final Item item = Item.getItemFromBlock(directedBlock);

--- a/src/main/java/appeng/helpers/DualityInterface.java
+++ b/src/main/java/appeng/helpers/DualityInterface.java
@@ -1456,18 +1456,10 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
 
                 if (what.getItem() != Items.AIR) {
                     /* getTranslationKey() and getUnlocalizedNameInefficiently() have different return values in some mod 
-                     *
-                     * For small item output of a formed machine in mod Modular Machinery Community Edition.
-                     * getTranslationKey() returns "tile.modularmachinery.blockinputbus"
-                     * getUnlocalizedNameInefficiently() return "tile.modularmachinery.blockinputbus.small"
-                     * Because modular machinery community edition overides getUnlocalizedNameInefficiently()
-                     * 
                      * For the Thermal Expansion
                      * getTranslationKey() returns complete key ending with ".name".
                      * getUnlocalizedNameInefficiently() returns localized name
                      * Because CoFH Core overrides method getTranslationKey()
-                     * 
-                     * Waiting MMCE overrides getTranslationKey
                      */
                     return what.getItem().getTranslationKey(what);
                 }

--- a/src/main/java/appeng/helpers/DualityInterface.java
+++ b/src/main/java/appeng/helpers/DualityInterface.java
@@ -1455,8 +1455,7 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
                 }
 
                 if (what.getItem() != Items.AIR) {
-                    /* FIX ME:
-                     * getTranslationKey() and getUnlocalizedNameInefficiently() have different return values in some mod 
+                    /* getTranslationKey() and getUnlocalizedNameInefficiently() have different return values in some mod 
                      *
                      * For small item output of a formed machine in mod Modular Machinery Community Edition.
                      * getTranslationKey() returns "tile.modularmachinery.blockinputbus"
@@ -1468,9 +1467,9 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
                      * getUnlocalizedNameInefficiently() returns localized name
                      * Because CoFH Core overrides method getTranslationKey()
                      * 
-                     * So is code is invalid to Thermal Expansion.
+                     * Waiting MMCE overrides getTranslationKey
                      */
-                    return what.getItem().getUnlocalizedNameInefficiently(what);
+                    return what.getItem().getTranslationKey(what);
                 }
 
                 final Item item = Item.getItemFromBlock(directedBlock);


### PR DESCRIPTION
Fix https://github.com/AE2-UEL/Applied-Energistics-2/issues/521 , and molecular assembler filter is work for other language.
Using the method getTranslationKey, this fix needs to getTranslationKey works properly in other mods.
Waiting MMCE overrides this method https://github.com/NovaEngineering-Source/ModularMachinery-Community-Edition/issues/131.
