### PR TITLE
Fix Hotbar Switching on Locked Slots

### DIFF
--- a/src/main/java/appeng/client/gui/AEBaseGui.java
+++ b/src/main/java/appeng/client/gui/AEBaseGui.java
@@ -69,6 +69,7 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.fml.common.Optional;
+import net.minecraftforge.items.wrapper.PlayerInvWrapper;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
@@ -655,9 +656,12 @@ public abstract class AEBaseGui extends GuiContainer implements IMTModGuiContain
                 if (keyCode == this.mc.gameSettings.keyBindsHotbar[j].getKeyCode()) {
                     final List<Slot> slots = this.getInventorySlots();
                     for (final Slot s : slots) {
-                        if (s.getSlotIndex() == j && s.inventory == ((AEBaseContainer) this.inventorySlots).getPlayerInv()) {
-                            if (!s.canTakeStack(((AEBaseContainer) this.inventorySlots).getPlayerInv().player)) {
-                                return false;
+                        if (s.getSlotIndex() == j) {
+                            if (s.inventory == ((AEBaseContainer) this.inventorySlots).getPlayerInv() ||
+                                    ((s instanceof AppEngSlot app) && (app.getItemHandler() instanceof PlayerInvWrapper))) {
+                                if (!s.canTakeStack(((AEBaseContainer) this.inventorySlots).getPlayerInv().player)) {
+                                    return false;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
This PR fixes hotbar switching still being an usable operation on locked hotbar slots.

This issue stemmed from the fact that AEBaseContainer initalizes hotbar slots using `PlayerInvWrapper` and not directly setting the inventory, causing the relevant check in `checkHotbarKeys` to always return false. (see https://github.com/AE2-UEL/Applied-Energistics-2/blob/master/src/main/java/appeng/container/AEBaseContainer.java#L248-L260)

This PR allows the locked slot check to accept either the original condition or the item handler being `PlayerInvWrapper`, thus fixing the issue. Another worthy method to consider that would also fix the issue would be removing the check entirely, which I can do if the reviewers believe it would be a better method.

Applies part of https://github.com/Nomi-CEu/Nomi-Labs/commit/3369c7a7e77f729909f96989d81f4c5dcc4e24e7.

Fixes https://github.com/AE2-UEL/Applied-Energistics-2/issues/541
Fixes hotbar switching whilst in Wireless Terminal or Portable Cell GUIs causing the GUI to auto-close