### PR TITLE
Improve Keybind Handling in Various AE2 GUIs

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiFluidInterfaceConfigurationTerminal.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiFluidInterfaceConfigurationTerminal.java
@@ -55,6 +55,7 @@ import net.minecraft.nbt.NBTUtil;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraftforge.common.DimensionManager;
+import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 
 import java.awt.*;
@@ -110,6 +111,7 @@ public class GuiFluidInterfaceConfigurationTerminal extends AEBaseGui implements
 
     @Override
     public void initGui() {
+        Keyboard.enableRepeatEvents(true);
         super.initGui();
 
         this.getScrollBar().setLeft(189);
@@ -130,6 +132,7 @@ public class GuiFluidInterfaceConfigurationTerminal extends AEBaseGui implements
     public void onGuiClosed() {
         partInterfaceTerminal.saveSearchStrings(this.searchFieldInputs.getText().toLowerCase());
         super.onGuiClosed();
+        Keyboard.enableRepeatEvents(false);
     }
 
     @Override

--- a/src/main/java/appeng/client/gui/implementations/GuiInterfaceConfigurationTerminal.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiInterfaceConfigurationTerminal.java
@@ -101,6 +101,7 @@ public class GuiInterfaceConfigurationTerminal extends AEBaseGui implements IJEI
 
     @Override
     public void initGui() {
+        Keyboard.enableRepeatEvents(true);
         super.initGui();
 
         this.getScrollBar().setLeft(189);
@@ -121,6 +122,7 @@ public class GuiInterfaceConfigurationTerminal extends AEBaseGui implements IJEI
     public void onGuiClosed() {
         partInterfaceTerminal.saveSearchStrings(this.searchFieldInputs.getText().toLowerCase());
         super.onGuiClosed();
+        Keyboard.enableRepeatEvents(false);
     }
 
     @Override

--- a/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
@@ -56,6 +56,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.common.util.Constants;
+import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 
 import java.awt.*;
@@ -178,6 +179,7 @@ public class GuiInterfaceTerminal extends AEBaseGui {
 
     @Override
     public void initGui() {
+        Keyboard.enableRepeatEvents(true);
         this.rows = calculateRowsCount();
 
         super.initGui();
@@ -204,6 +206,12 @@ public class GuiInterfaceTerminal extends AEBaseGui {
 
         this.setScrollBar();
         this.repositionSlots();
+    }
+
+    @Override
+    public void onGuiClosed() {
+        super.onGuiClosed();
+        Keyboard.enableRepeatEvents(false);
     }
 
     protected void repositionSlots() {

--- a/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
@@ -119,7 +119,6 @@ public class GuiInterfaceTerminal extends AEBaseGui {
         searchFieldInputs = createTextField(86, 12, ButtonToolTips.SearchFieldInputs.getLocal());
         searchFieldOutputs = createTextField(86, 12, ButtonToolTips.SearchFieldOutputs.getLocal());
         searchFieldNames = createTextField(71, 12, ButtonToolTips.SearchFieldNames.getLocal());
-        searchFieldNames.setFocused(true);
 
         guiButtonAssemblersOnly = new GuiImgButton(0, 0, Settings.ACTIONS, null);
         guiButtonHideFull = new GuiImgButton(0, 0, Settings.ACTIONS, null);
@@ -141,7 +140,6 @@ public class GuiInterfaceTerminal extends AEBaseGui {
         searchFieldInputs = createTextField(86, 12, ButtonToolTips.SearchFieldInputs.getLocal());
         searchFieldOutputs = createTextField(86, 12, ButtonToolTips.SearchFieldOutputs.getLocal());
         searchFieldNames = createTextField(71, 12, ButtonToolTips.SearchFieldNames.getLocal());
-        searchFieldNames.setFocused(true);
 
         guiButtonAssemblersOnly = new GuiImgButton(0, 0, Settings.ACTIONS, null);
         guiButtonHideFull = new GuiImgButton(0, 0, Settings.ACTIONS, null);
@@ -194,6 +192,8 @@ public class GuiInterfaceTerminal extends AEBaseGui {
         searchFieldOutputs.y = guiTop + 38;
         searchFieldNames.x = guiLeft + 32 + 99;
         searchFieldNames.y = guiTop + 38;
+
+        searchFieldNames.setFocused(true);
 
         terminalStyleBox.x = guiLeft - 18;
         terminalStyleBox.y = guiTop + 8 + jeiButtonPadding;

--- a/src/main/java/appeng/client/gui/implementations/GuiOreDictStorageBus.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiOreDictStorageBus.java
@@ -44,6 +44,18 @@ public class GuiOreDictStorageBus extends GuiUpgradeable {
     }
 
     @Override
+    public void initGui() {
+        Keyboard.enableRepeatEvents(true);
+        super.initGui();
+    }
+
+    @Override
+    public void onGuiClosed() {
+        super.onGuiClosed();
+        Keyboard.enableRepeatEvents(false);
+    }
+
+    @Override
     protected void addButtons() {
         this.searchFieldInputs = new MEGuiTextField(this.fontRenderer, this.guiLeft + 3, this.guiTop + 22, 170, 12);
         this.searchFieldInputs.setEnableBackgroundDrawing(false);

--- a/src/main/java/appeng/client/gui/implementations/GuiOreDictStorageBus.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiOreDictStorageBus.java
@@ -110,7 +110,7 @@ public class GuiOreDictStorageBus extends GuiUpgradeable {
     @Override
     protected void keyTyped(final char character, final int key) throws IOException {
         if (!this.checkHotbarKeys(key)) {
-            if (key == Keyboard.KEY_RETURN || key == Keyboard.KEY_NUMPADENTER) {
+            if (key == Keyboard.KEY_ESCAPE ||key == Keyboard.KEY_RETURN || key == Keyboard.KEY_NUMPADENTER) {
                 searchFieldInputs.setText(OreDictFilterMatcher.validateExp(searchFieldInputs.getText()));
                 NetworkHandler.instance().sendToServer(new PacketValueConfig("OreDictStorageBus.save", searchFieldInputs.getText()));
             }

--- a/src/main/java/appeng/client/gui/implementations/GuiRenamer.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiRenamer.java
@@ -25,6 +25,7 @@ public class GuiRenamer extends AEBaseGui {
 
     @Override
     public void initGui() {
+        Keyboard.enableRepeatEvents(true);
         super.initGui();
 
         this.textField = new MEGuiTextField(this.fontRenderer, this.guiLeft + 9, this.guiTop + 33, 229, 12);
@@ -37,6 +38,12 @@ public class GuiRenamer extends AEBaseGui {
         this.buttonList.add(this.confirmButton = new GuiButton(0, this.guiLeft + 238, this.guiTop + 33, 12, 12, "↵"));
 
         ((ContainerRenamer) this.inventorySlots).setTextField(this.textField);
+    }
+
+    @Override
+    public void onGuiClosed() {
+        super.onGuiClosed();
+        Keyboard.enableRepeatEvents(false);
     }
 
     @Override

--- a/src/main/java/appeng/client/gui/implementations/GuiRenamer.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiRenamer.java
@@ -64,7 +64,7 @@ public class GuiRenamer extends AEBaseGui {
 
     @Override
     protected void keyTyped(final char character, final int key) throws IOException {
-        if (key == Keyboard.KEY_RETURN || key == Keyboard.KEY_NUMPADENTER) { // Enter
+        if (key == Keyboard.KEY_ESCAPE || key == Keyboard.KEY_RETURN || key == Keyboard.KEY_NUMPADENTER) { // Enter
             try {
                 NetworkHandler.instance().sendToServer(
                         new PacketValueConfig("QuartzKnife.ReName", this.textField.getText()));

--- a/src/main/java/appeng/fluids/client/gui/GuiFluidTerminal.java
+++ b/src/main/java/appeng/fluids/client/gui/GuiFluidTerminal.java
@@ -48,6 +48,7 @@ import net.minecraft.inventory.ClickType;
 import net.minecraft.inventory.Slot;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fml.common.Loader;
+import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 
 import java.io.IOException;
@@ -96,6 +97,8 @@ public class GuiFluidTerminal extends AEBaseMEGui implements ISortSource, IConfi
 
     @Override
     public void initGui() {
+        Keyboard.enableRepeatEvents(true);
+
         this.mc.player.openContainer = this.inventorySlots;
         this.guiLeft = (this.width - this.xSize) / 2;
         this.guiTop = (this.height - this.ySize) / 2;
@@ -123,6 +126,12 @@ public class GuiFluidTerminal extends AEBaseMEGui implements ISortSource, IConfi
             }
         }
         this.setScrollBar();
+    }
+
+    @Override
+    public void onGuiClosed() {
+        super.onGuiClosed();
+        Keyboard.enableRepeatEvents(false);
     }
 
     @Override

--- a/src/main/java/appeng/fluids/client/gui/GuiMEPortableFluidCell.java
+++ b/src/main/java/appeng/fluids/client/gui/GuiMEPortableFluidCell.java
@@ -50,6 +50,7 @@ import net.minecraft.inventory.ClickType;
 import net.minecraft.inventory.Slot;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fml.common.Loader;
+import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 
 import javax.annotation.Nonnull;
@@ -90,6 +91,7 @@ public class GuiMEPortableFluidCell extends AEBaseMEGui implements ISortSource, 
 
     @Override
     public void initGui() {
+        Keyboard.enableRepeatEvents(true);
         this.mc.player.openContainer = this.inventorySlots;
         this.guiLeft = (this.width - this.xSize) / 2;
         this.guiTop = (this.height - this.ySize) / 2;
@@ -117,6 +119,12 @@ public class GuiMEPortableFluidCell extends AEBaseMEGui implements ISortSource, 
             }
         }
         this.setScrollBar();
+    }
+
+    @Override
+    public void onGuiClosed() {
+        super.onGuiClosed();
+        Keyboard.enableRepeatEvents(false);
     }
 
     @Override


### PR DESCRIPTION
This PR improves key handling in three ways:
- Saves OreDictStorageBus and Renamer on pressing the `ESCAPE` key, instead of simply exiting the GUI and not saving (Pressing `RETURN/ENTER` already does this)
- Properly allows repeat keyboard events in all AE2 GUIs with text entry fields, allowing for players to hold keys
- Properly autofocuses the Interface Terminal search field, to prevent other mods' keybinds from triggering

Contains aspects of https://github.com/Nomi-CEu/Nomi-Labs/commit/397b36bd846834568d0508de9dd95e554995006a and contains all of https://github.com/Nomi-CEu/Nomi-Labs/commit/0e82e8189ac334e297deaddd7f29489e3df32cbb.