### PR TITLE
Fix copying interfaces filled with patterns

### DIFF
--- a/src/main/java/appeng/parts/misc/PartInterface.java
+++ b/src/main/java/appeng/parts/misc/PartInterface.java
@@ -321,7 +321,7 @@ public class PartInterface extends PartBasicState implements IGridTickable, ISto
             PlayerMainInvWrapper playerInv = new PlayerMainInvWrapper(player.inventory);
             final IMaterials materials = AEApi.instance().definitions().materials();
             int missingPatternsToEncode = 0;
-            int amountPatternSlots = 8 + this.getInstalledUpgrades(Upgrades.PATTERN_EXPANSION) * 9;
+            int amountPatternSlots = 9 + this.getInstalledUpgrades(Upgrades.PATTERN_EXPANSION) * 9;
 
             for (int i = 0; i < inv.getSlots(); i++) {
                 if (target.getStackInSlot(i).getItem() instanceof ItemEncodedPattern) {

--- a/src/main/java/appeng/tile/misc/TileInterface.java
+++ b/src/main/java/appeng/tile/misc/TileInterface.java
@@ -352,7 +352,7 @@ public class TileInterface extends AENetworkInvTile implements IGridTickable, II
             PlayerMainInvWrapper playerInv = new PlayerMainInvWrapper(player.inventory);
             final IMaterials materials = AEApi.instance().definitions().materials();
             int missingPatternsToEncode = 0;
-            int amountPatternSlots = 8 + this.getInstalledUpgrades(Upgrades.PATTERN_EXPANSION) * 9;
+            int amountPatternSlots = 9 + this.getInstalledUpgrades(Upgrades.PATTERN_EXPANSION) * 9;
 
             for (int i = 0; i < inv.getSlots(); i++) {
                 if (target.getStackInSlot(i).getItem() instanceof ItemEncodedPattern) {


### PR DESCRIPTION
Before:

Memory card has 9 patterns on it,

![image](https://github.com/user-attachments/assets/eb342540-0f5c-4a16-bbd4-82f56db29ff3)

but pasting only inserts 8 patterns into the interface.

![image](https://github.com/user-attachments/assets/518aa80f-464d-4bbd-8e11-07c593673f6c)

I have tested this and it works perfectly.