### PR TITLE
Prevent NPE when draining fluid contents from tankProperty

### DIFF
--- a/src/main/java/appeng/fluids/parts/FluidHandlerAdapter.java
+++ b/src/main/java/appeng/fluids/parts/FluidHandlerAdapter.java
@@ -195,7 +195,7 @@ public class FluidHandlerAdapter implements IMEInventory<IAEFluidStack>, IBaseMo
 
             for (IFluidTankProperties tankProperty : tankProperties) {
                 var contents = tankProperty.getContents();
-                if (this.mode == StorageFilter.EXTRACTABLE_ONLY && this.fluidHandler.drain(contents, false) == null) {
+                if (this.mode == StorageFilter.EXTRACTABLE_ONLY && (contents == null || this.fluidHandler.drain(contents, false) == null)) {
                     continue;
                 }
                 currentlyOnStorage.add(AEFluidStack.fromFluidStack(contents));


### PR DESCRIPTION
Since #483, `IFluidTankProperties#getContents()` is used. The method is marked `@Nullable`, so we should check nullability to be safe. Currently, this line can crash with NPE depending on the fluid handler's implementation. One example that causes crashes is a fluid storage bus on a fluid drawer.