### PR TITLE
Fix Improper Restrictions in Quantum Link Card Slot

### DIFF
--- a/src/main/java/appeng/container/slot/SlotRestrictedInput.java
+++ b/src/main/java/appeng/container/slot/SlotRestrictedInput.java
@@ -44,6 +44,8 @@ import net.minecraft.world.World;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.oredict.OreDictionary;
 
+import java.util.Optional;
+
 
 /**
  * @author AlgorithmX2
@@ -206,10 +208,7 @@ public class SlotRestrictedInput extends AppEngSlot {
             case UPGRADES:
                 return i.getItem() instanceof IUpgradeModule && ((IUpgradeModule) i.getItem()).getType(i) != null;
             case CARD_QUANTUM:
-                if (AEApi.instance().definitions().materials().cardQuantumLink().maybeItem().isPresent()) {
-                    return AEApi.instance().definitions().materials().cardQuantumLink().maybeItem().get() == i.getItem();
-                }
-                return false;
+                return materials.cardQuantumLink().isSameAs(i);
             default:
                 break;
         }

--- a/src/main/java/appeng/container/slot/SlotRestrictedInput.java
+++ b/src/main/java/appeng/container/slot/SlotRestrictedInput.java
@@ -20,7 +20,6 @@ package appeng.container.slot;
 
 
 import appeng.api.AEApi;
-import appeng.api.config.Upgrades;
 import appeng.api.definitions.IDefinitions;
 import appeng.api.definitions.IItems;
 import appeng.api.definitions.IMaterials;
@@ -43,8 +42,6 @@ import net.minecraft.tileentity.TileEntityFurnace;
 import net.minecraft.world.World;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.oredict.OreDictionary;
-
-import java.util.Optional;
 
 
 /**


### PR DESCRIPTION
This PR fixes the Quantum Link Card restriction not checking for ItemStack meta, leading to other items being allowed in the Quantum Link Chamber's second slot.

To reproduce:
1. Place a Quantum Link Card in the Quantum Link Chamber
2. Hold an item with the same Item as the card (e.g. a Quantum Entangled Singularity)
3. Click on the Quantum Link Card; the Singularity goes in the second slot (it should go into the first).

This is not a huge issue, but does cause weird interactions and behaviours from the chamber.

This ports over the corresponding mixin commit in Labs: https://github.com/Nomi-CEu/Nomi-Labs/commit/969a9b792c5b3135c8efdd0fc7eadc282690c355