### PR TITLE
Fix server crash in TheOneProbe integration when viewing energy storage devices

### DIFF
--- a/src/main/java/appeng/integration/modules/theoneprobe/tile/PowerStorageInfoProvider.java
+++ b/src/main/java/appeng/integration/modules/theoneprobe/tile/PowerStorageInfoProvider.java
@@ -47,9 +47,14 @@ public class PowerStorageInfoProvider implements ITileProbInfoProvider {
 
                     final String formatCurrentPower = Platform.formatPowerLong(internalCurrentPower, false);
                     final String formatMaxPower = Platform.formatPowerLong(internalMaxPower, false);
-                    final String formattedString = String.format(TheOneProbeText.STORED_ENERGY.getLocal(), formatCurrentPower, formatMaxPower);
+                    StringBuilder sb = new StringBuilder();
+                    sb.append("§2")
+                            .append(formatCurrentPower)
+                            .append("§к / §4")
+                            .append(formatMaxPower)
+                            .append("§r");
 
-                    probeInfo.text(formattedString);
+                    probeInfo.text(sb.toString());
                 }
             }
         }


### PR DESCRIPTION
The One Probe integration causes server crashes when players view AE2 energy storage devices (ME Drives, Energy Cells, etc.). The server throws IllegalFormatConversionException due to type mismatch in string formatting.

ErrorLog:

``` debug
[08:06:53] [Server thread/DEBUG] [theoneprobe]: The One Probe catched error: 
java.util.IllegalFormatConversionException: d != java.lang.String
	at java.util.Formatter$FormatSpecifier.failConversion(Formatter.java:4515)
	at java.util.Formatter$FormatSpecifier.printInteger(Formatter.java:3066)
	at java.util.Formatter$FormatSpecifier.print(Formatter.java:3021)
	at java.util.Formatter.format(Formatter.java:2797)
	at java.util.Formatter.format(Formatter.java:2728)
	at java.lang.String.format(String.java:4390)
	at appeng.integration.modules.theoneprobe.tile.PowerStorageInfoProvider.addProbeInfo(PowerStorageInfoProvider.java:50)
	at appeng.integration.modules.theoneprobe.TileInfoProvider.addProbeInfo(TileInfoProvider.java:63)
	at mcjty.theoneprobe.network.PacketGetInfo.getProbeInfo(PacketGetInfo.java:148)
	at mcjty.theoneprobe.network.PacketGetInfo.access$000(PacketGetInfo.java:34)
	at mcjty.theoneprobe.network.PacketGetInfo$Handler.handle(PacketGetInfo.java:112)
	at mcjty.theoneprobe.network.PacketGetInfo$Handler.lambda$onMessage$0(PacketGetInfo.java:104)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at net.minecraft.util.Util.runTask(SourceFile:529)
	at net.minecraft.server.MinecraftServer.updateTimeLightAndEntities(MinecraftServer.java:723)
	at net.minecraft.server.dedicated.DedicatedServer.updateTimeLightAndEntities(DedicatedServer.java:399)
	at net.minecraft.server.MinecraftServer.tick(MinecraftServer.java:668)
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:526)
	at java.lang.Thread.run(Thread.java:1583)
```

<img width="2560" height="1494" alt="2F957AA5C91E3D60A3D8B9301F41F92E" src="https://github.com/user-attachments/assets/6de6e545-e2c5-462e-b05e-792a0740a00b" />