### PR TITLE
fix fluid storage bus resetCache spam

### DIFF
--- a/src/main/java/appeng/fluids/parts/PartFluidStorageBus.java
+++ b/src/main/java/appeng/fluids/parts/PartFluidStorageBus.java
@@ -267,13 +267,23 @@ public class PartFluidStorageBus extends PartUpgradeable implements IGridTickabl
             // In case the TE was destroyed, we have to do a full reset immediately.
             if (te instanceof TileCableBus) {
                 IPart iPart = ((TileCableBus) te).getPart(this.getSide().getOpposite());
-                if (iPart == null || iPart instanceof PartFluidInterface) {
+                if (iPart == null) {
+                    this.resetCache(true);
+                    this.resetCache();
+                } else if (iPart instanceof PartFluidInterface) {
+                    if (createHandlerHash(te) != handlerHash) {
+                        this.resetCache(true);
+                        this.resetCache();
+                    }
+                }
+            } else if (te == null) {
+                this.resetCache(true);
+                this.resetCache();
+            } else if (te instanceof TileFluidInterface) {
+                if (createHandlerHash(te) != handlerHash) {
                     this.resetCache(true);
                     this.resetCache();
                 }
-            } else if (te == null || te instanceof TileFluidInterface) {
-                this.resetCache(true);
-                this.resetCache();
             } else {
                 this.resetCache(false);
             }


### PR DESCRIPTION
`onNeighborChanged` gets called when the connected block changes, which happens a lot if you for example have a `FluidStorageBus` connected to a `FluidInterface` with stocked fluids. 
What will happen before this change using this setup is that every time the `FluidStorageBus` pulls fluids from the `FluidInterface`, the `FluidInterface` will `markDirty()` which causes an `onNeighborChanged` of the `FluidStorageBus`, which in turn will call `resetCache()`, because its a `FluidInterface` it is next to.

Now the normal item `StorageBus` already [handles it correctly](https://github.com/AE2-UEL/Applied-Energistics-2/blob/26bb5986c636e9bdde62559b0d1c2bbc48c4b9e3/src/main/java/appeng/parts/misc/PartStorageBus.java#L261): comparing the handler hash before the `resetCache` call, which will correctly skip the `resetCache` in the described setup.

This PR simply copies the same behaviour 1 to 1 to the `FluidStorageBus`