### PR TITLE
Fix Ghost Item Behaviour for Newest HEI

### DIFF
--- a/src/main/java/appeng/client/ClientHelper.java
+++ b/src/main/java/appeng/client/ClientHelper.java
@@ -79,6 +79,7 @@ import static appeng.client.KeyBindings.*;
 
 public class ClientHelper extends ServerHelper {
     public final static String KEY_CATEGORY = "key.appliedenergistics2.category";
+    public static boolean isHei = false;
 
     private final EnumMap<ActionKey, KeyBinding> bindings = new EnumMap<>(ActionKey.class);
     private final List<KeyBinding> keyBindings = new ArrayList<>();
@@ -89,6 +90,17 @@ public class ClientHelper extends ServerHelper {
         // Do not register the Fullbright hacks if Optifine is present or if the Forge lighting is disabled
         if (!FMLClientHandler.instance().hasOptifine() && ForgeModContainer.forgeLightPipelineEnabled) {
             ModelLoaderRegistry.registerLoader(UVLModelLoader.INSTANCE);
+        }
+
+        // This is very cursed, but it effectively determines if we are on hei,
+        // and on a new enough version that the ghost ingredient handler supports the bookmarks tab
+        if (Platform.isModLoaded("jei")) {
+            try {
+                Class.forName("mezz.jei.bookmarks.BookmarkItem");
+                isHei = true;
+            } catch (ClassNotFoundException ignored) {
+                isHei = false;
+            }
         }
 
         RenderingRegistry.registerEntityRenderingHandler(EntityTinyTNTPrimed.class, manager -> new RenderTinyTNTPrimed(manager));
@@ -291,6 +303,9 @@ public class ClientHelper extends ServerHelper {
 
     @SubscribeEvent
     public void MouseClickEvent(final GuiScreenEvent.MouseInputEvent.Pre me) {
+        // Only cancel JEI's bookmark handling if we are NOT on hei
+        if (isHei) return;
+
         final Minecraft mc = Minecraft.getMinecraft();
         if (mc.currentScreen instanceof IJEIGhostIngredients) {
             AEBaseGui gui = ((AEBaseGui) mc.currentScreen);

--- a/src/main/java/appeng/client/gui/AEBaseGui.java
+++ b/src/main/java/appeng/client/gui/AEBaseGui.java
@@ -21,6 +21,7 @@ package appeng.client.gui;
 
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEItemStack;
+import appeng.client.ClientHelper;
 import appeng.client.gui.widgets.GuiCustomSlot;
 import appeng.client.gui.widgets.GuiScrollbar;
 import appeng.client.gui.widgets.ITooltip;
@@ -190,7 +191,7 @@ public abstract class AEBaseGui extends GuiContainer implements IMTModGuiContain
             }
         }
         GlStateManager.enableDepth();
-        if (Platform.isModLoaded("jei")) {
+        if (Platform.isModLoaded("jei") && !ClientHelper.isHei) {
             bookmarkedJEIghostItem(mouseX, mouseY);
         }
         GlStateManager.disableDepth();

--- a/src/main/java/appeng/client/gui/AEGuiHandler.java
+++ b/src/main/java/appeng/client/gui/AEGuiHandler.java
@@ -1,6 +1,7 @@
 package appeng.client.gui;
 
 import appeng.api.storage.data.IAEItemStack;
+import appeng.client.ClientHelper;
 import appeng.client.gui.implementations.GuiCraftAmount;
 import appeng.client.gui.implementations.GuiCraftConfirm;
 import appeng.client.gui.implementations.GuiCraftingCPU;
@@ -11,17 +12,21 @@ import appeng.client.gui.widgets.GuiCustomSlot;
 import appeng.container.interfaces.IJEIGhostIngredients;
 import appeng.container.interfaces.ISpecialSlotIngredient;
 import appeng.container.slot.IJEITargetSlot;
+import appeng.core.AELog;
 import mezz.jei.api.gui.IAdvancedGuiHandler;
 import mezz.jei.api.gui.IGhostIngredientHandler;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.inventory.Slot;
+import org.jetbrains.annotations.NotNull;
 import org.lwjgl.input.Mouse;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.awt.*;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 
@@ -118,25 +123,51 @@ public class AEGuiHandler implements IAdvancedGuiHandler<AEBaseGui>, IGhostIngre
     @Override
     @Nonnull
     public <I> List<Target<I>> getTargets(@Nonnull AEBaseGui gui, @Nonnull I ingredient, boolean doStart) {
-        ArrayList<Target<I>> targets = new ArrayList<>();
-        if (gui instanceof IJEIGhostIngredients g) {
-            List<Target<?>> phantomTargets = g.getPhantomTargets(ingredient);
-            targets.addAll((List<Target<I>>) (Object) phantomTargets);
-        }
-        if (doStart && GuiScreen.isShiftKeyDown() && Mouse.isButtonDown(0)) {
-            if (gui instanceof GuiUpgradeable || gui instanceof GuiPatternTerm || gui instanceof GuiExpandedProcessingPatternTerm) {
-                IJEIGhostIngredients ghostGui = ((IJEIGhostIngredients) gui);
-                for (Target<I> target : targets) {
-                    if (ghostGui.getFakeSlotTargetMap().get(target) instanceof IJEITargetSlot jeiSlot) {
-                        if (jeiSlot.needAccept()) {
-                            target.accept(ingredient);
-                            break;
+        if (!(gui instanceof IJEIGhostIngredients g)) return Collections.emptyList();
+
+        // HEI Specific Behaviour
+        if (ClientHelper.isHei) {
+            Object ingToUse = getIngFromBookmarkItem(ingredient);
+            if (ingToUse != null) {
+                List<Target<Object>> phantomTargets = (List<Target<Object>>) (Object) g.getPhantomTargets(ingToUse);
+
+                List<Target<I>> result = new ArrayList<>();
+                for (Target<Object> target : phantomTargets) {
+                    result.add(new Target<>() {
+                        @Override
+                        public @NotNull Rectangle getArea() {
+                            return target.getArea();
                         }
-                    }
+
+                        @Override
+                        public void accept(@NotNull I ingredient) {
+                            Object ingToUse = getIngFromBookmarkItem(ingredient);
+                            if (ingToUse != null) {
+                                target.accept(ingToUse);
+                            }
+                        }
+                    });
                 }
+
+                return result;
             }
         }
-        return targets;
+
+        return (List<Target<I>>) (Object) g.getPhantomTargets(ingredient);
+    }
+
+    @Nullable
+    private Object getIngFromBookmarkItem(Object ingredient) {
+        try {
+            Class<?> bookmarkItemClass = Class.forName("mezz.jei.bookmarks.BookmarkItem");
+            if (bookmarkItemClass.isAssignableFrom(ingredient.getClass())) {
+                Field ingredientField = bookmarkItemClass.getDeclaredField("ingredient");
+                return ingredientField.get(ingredient);
+            }
+        } catch (ClassNotFoundException | NoSuchFieldException | IllegalAccessException e) {
+            AELog.error("Could not normalise bookmark item ingredient: ", e);
+        }
+        return null;
     }
 
     @Override

--- a/src/main/java/appeng/client/gui/implementations/GuiFluidInterfaceConfigurationTerminal.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiFluidInterfaceConfigurationTerminal.java
@@ -55,6 +55,7 @@ import net.minecraft.nbt.NBTUtil;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraftforge.common.DimensionManager;
+import net.minecraftforge.fluids.FluidStack;
 import org.lwjgl.input.Mouse;
 
 import java.awt.*;
@@ -459,13 +460,13 @@ public class GuiFluidInterfaceConfigurationTerminal extends AEBaseGui implements
 
     @Override
     public List<IGhostIngredientHandler.Target<?>> getPhantomTargets(Object ingredient) {
-        if (!(ingredient instanceof ItemStack)) {
+        if (!(ingredient instanceof FluidStack)) {
             return Collections.emptyList();
         }
         List<IGhostIngredientHandler.Target<?>> targets = new ArrayList<>();
         for (Slot slot : this.inventorySlots.inventorySlots) {
             if (slot instanceof SlotDisconnected) {
-                ItemStack itemStack = (ItemStack) ingredient;
+                FluidStack fluidStack = (FluidStack) ingredient;
                 IGhostIngredientHandler.Target<Object> target = new IGhostIngredientHandler.Target<Object>() {
                     @Override
                     public Rectangle getArea() {
@@ -476,7 +477,7 @@ public class GuiFluidInterfaceConfigurationTerminal extends AEBaseGui implements
                     public void accept(Object ingredient) {
                         final PacketInventoryAction p;
                         try {
-                            p = new PacketInventoryAction(InventoryAction.PLACE_JEI_GHOST_ITEM, (SlotDisconnected) slot, AEItemStack.fromItemStack(itemStack));
+                            p = new PacketInventoryAction(InventoryAction.PLACE_JEI_GHOST_ITEM, (SlotDisconnected) slot, AEItemStack.fromItemStack(AEFluidStack.fromFluidStack(fluidStack).asItemStackRepresentation()));
                             NetworkHandler.instance().sendToServer(p);
 
                         } catch (IOException e) {


### PR DESCRIPTION
This PR fixes the bookmark bar being un-interactable, in AE2 guis, with latest HEI.

This is fixed by adding special handling for HEI: disabling the cancellation of the `MouseEvent.Pre`, and adding support for targets for `BookmarkItem`. This has been done without a hard dependency on JEI; the original behaviour is still kept for JEI, and older HEI versions.

Fixes https://github.com/CleanroomMC/HadEnoughItems/issues/149

This PR has been tested with:
- JEI
- Newest HEI
- AE2 Fluid Crafting (with Newest HEI, confirming ghost items for bookmarks works there)