### PR TITLE
Fix getEnergyCanBeInserted calling itself twice on the next container with GTEU P2P

### DIFF
--- a/src/main/java/appeng/parts/p2p/PartP2PGTCEPower.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PGTCEPower.java
@@ -94,10 +94,11 @@ public class PartP2PGTCEPower extends PartP2PTunnel<PartP2PGTCEPower> {
                 if (output == this) {
                     return 0;
                 }
-                if (output == null || output.getEnergyCanBeInserted() <= 0) {
+                long energy = output.getEnergyCanBeInserted();
+                if (output == null || energy <= 0) {
                     continue;
                 }
-                canInsert += output.getEnergyCanBeInserted();
+                canInsert += energy;
             }
             return canInsert;
         }


### PR DESCRIPTION
This led to severe TPS reduction or even server crashes when a large amount of GTEU P2Ps were chained one after the other.
To reproduce, chain at least 16 GTEU P2Ps together, add an energy input and an energy output, then observe tps/mspt with `/forge tps`
Without the fix :
<img width="2557" height="1351" alt="without_fix" src="https://github.com/user-attachments/assets/e3074471-9caa-4dca-b506-e420e8bc6274" />
With the fix :
<img width="2557" height="1351" alt="with_fix" src="https://github.com/user-attachments/assets/001c0f14-0b55-40d7-be20-419cee5003bb" />

