### PR TITLE
Fix meta get on some blocks

### DIFF
--- a/src/main/java/appeng/parts/automation/PartAnnihilationPlane.java
+++ b/src/main/java/appeng/parts/automation/PartAnnihilationPlane.java
@@ -455,7 +455,7 @@ public class PartAnnihilationPlane extends PartBasicState implements IGridTickab
             if (item != Items.AIR) {
                 int meta = 0;
                 if (item.getHasSubtypes()) {
-                    meta = state.getBlock().getMetaFromState(state);
+                    meta = state.getBlock().damageDropped(state);
                 }
                 final ItemStack itemstack = new ItemStack(item, 1, meta);
                 out.add(itemstack);

--- a/src/main/java/appeng/parts/automation/PartIdentityAnnihilationPlane.java
+++ b/src/main/java/appeng/parts/automation/PartIdentityAnnihilationPlane.java
@@ -75,7 +75,7 @@ public class PartIdentityAnnihilationPlane extends PartAnnihilationPlane {
             if (item != Items.AIR) {
                 int meta = 0;
                 if (item.getHasSubtypes()) {
-                    meta = state.getBlock().getMetaFromState(state);
+                    meta = state.getBlock().damageDropped(state);
                 }
                 final ItemStack itemstack = new ItemStack(item, 1, meta);
                 out.add(itemstack);


### PR DESCRIPTION
Fixes #587 

Vanilla Leaf uses a different API to handle the Meta of dropped items, but this method isn't necessarily implemented in all mods. Although the function comments state it's the standard function, it could potentially cause Meta anomalies for other mod items.