### PR TITLE
- Improved ME Terminal search syntax (OR, prefixes, quotes)

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
@@ -286,7 +286,7 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
 
         this.searchField = new MEGuiTextField(this.fontRenderer, this.guiLeft + Math.max(80, this.offsetX), this.guiTop + 4, 90, 12);
         this.searchField.setEnableBackgroundDrawing(false);
-        this.searchField.setMaxStringLength(25);
+        this.searchField.setMaxStringLength(60);
         this.searchField.setTextColor(0xFFFFFF);
         this.searchField.setSelectionColor(0xFF008000);
         this.searchField.setVisible(true);

--- a/src/main/java/appeng/client/me/ItemRepo.java
+++ b/src/main/java/appeng/client/me/ItemRepo.java
@@ -34,13 +34,16 @@ import appeng.util.ItemSorters;
 import appeng.util.Platform;
 import appeng.util.prioritylist.IPartitionList;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.ModContainer;
+import net.minecraftforge.oredict.OreDictionary;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.regex.Pattern;
-
+import java.util.Locale;
 
 public class ItemRepo {
 
@@ -53,7 +56,6 @@ public class ItemRepo {
 
     private String searchString = "";
     private IPartitionList<IAEItemStack> myPartitionList;
-    private String innerSearch = "";
     private boolean hasPower;
 
     private Enum lastView;
@@ -186,68 +188,206 @@ public class ItemRepo {
 
         final boolean needsZeroCopy = viewMode == ViewItems.CRAFTABLE;
 
-        final boolean terminalSearchToolTips = AEConfig.instance().getConfigManager().getSetting(Settings.SEARCH_TOOLTIPS) != YesNo.NO;
-
-        boolean searchMod = false;
-
-        this.innerSearch = searchString.toLowerCase();
-        if (this.innerSearch.startsWith("@")) {
-            searchMod = true;
-            this.innerSearch = this.innerSearch.substring(1);
-        }
-
-        Pattern m = null;
-        try {
-            m = Pattern.compile(this.innerSearch, Pattern.CASE_INSENSITIVE);
-        } catch (final Throwable ignore) {
-            try {
-                m = Pattern.compile(Pattern.quote(this.innerSearch), Pattern.CASE_INSENSITIVE);
-            } catch (final Throwable __) {
-                return;
-            }
-        }
-
-        if (this.myPartitionList != null) {
-            if (!this.myPartitionList.isListed(is)) {
-                return;
-            }
+        if (this.myPartitionList != null && !this.myPartitionList.isListed(is)) {
+            return;
         }
 
         if (viewMode == ViewItems.CRAFTABLE && !is.isCraftable()) {
             return;
         }
-
         if (viewMode == ViewItems.STORED && is.getStackSize() == 0) {
             return;
         }
 
-        final String dspName = (searchMod ? Platform.getModId(is) : Platform.getItemDisplayName(is)).toLowerCase();
-        boolean foundMatchingItemStack = true;
+        final String query = lower(this.searchString).trim();
+        if (query.isEmpty()) {
+            if (needsZeroCopy) {
+                IAEItemStack copy = is.copy();
+                copy.setStackSize(0);
+                this.view.add(copy);
+            } else {
+                this.view.add(is);
+            }
+            return;
+        }
 
-        for (String term : innerSearch.split(" ")) {
-            if (term.length() > 1 && (term.startsWith("-") || term.startsWith("!"))) {
-                term = term.substring(1);
-                if (dspName.contains(term)) {
-                    foundMatchingItemStack = false;
+        // Original setting behavior:
+        // enabled = normal terms also search tooltip
+        // disabled = only # searches tooltip
+        final boolean tooltipSearchEnabled =
+                AEConfig.instance().getConfigManager().getSetting(Settings.SEARCH_TOOLTIPS) != YesNo.NO;
+
+        // Base strings (null-safe)
+        final String itemName = lower(Platform.getItemDisplayName(is));
+        String modId = null;
+        String modName = null;
+
+        // Lazy stuff only computed if a term needs it
+        ItemStack stack = null;
+        String registryId = null;
+
+        // Two tooltip caches:
+        // tooltipLower: normal lowercase tooltip (keeps spaces), used for "old setting" behavior
+        // tooltipText: normalized tooltip (spaces removed), used for explicit # searching like modern
+        String tooltipLower = null;
+        String tooltipText = null;
+
+        int[] oreIds = null;
+
+        boolean found = false;
+
+        // OR groups split by |
+        for (String orPart : query.split("\\|")) {
+            String part = orPart.trim();
+
+            // Empty OR part matches everything
+            if (part.isEmpty()) {
+                found = true;
+                break;
+            }
+
+            boolean groupMatches = true;
+
+            // AND terms split by spaces
+            for (String raw : splitSearchTerms(part)) {
+                if (raw.isEmpty()) {
+                    continue;
+                }
+
+                boolean neg = false;
+                char c0 = raw.charAt(0);
+                if (c0 == '-' || c0 == '!') {
+                    neg = true;
+                    raw = raw.substring(1);
+                    if (raw.isEmpty()) {
+                        continue;
+                    }
+                }
+
+                char prefix = raw.charAt(0);
+                String term = raw;
+
+                enum Target { NAME, MOD, TOOLTIP, OREDICT, REGISTRY }
+                Target target = Target.NAME;
+
+                if (prefix == '@' || prefix == '#' || prefix == '$' || prefix == '&' || prefix == '*') {
+                    term = raw.substring(1);
+                    if (term.isEmpty()) {
+                        continue;
+                    }
+
+                    if (prefix == '@') target = Target.MOD;
+                    else if (prefix == '#') target = Target.TOOLTIP;
+                    else if (prefix == '$') target = Target.OREDICT;
+                    else target = Target.REGISTRY; // & or *
+                }
+
+                boolean termMatches = false;
+
+                switch (target) {
+                    case NAME:
+                        termMatches = itemName.contains(term);
+
+                        if (!termMatches && tooltipSearchEnabled) {
+                            if (tooltipLower == null) {
+                                List<String> lines = Platform.getTooltip(is);
+                                StringBuilder sb = new StringBuilder();
+                                for (int i = 0; i < lines.size(); i++) {
+                                    String line = lines.get(i);
+                                    if (line == null) continue;
+                                    if (sb.length() > 0) sb.append('\n');
+                                    sb.append(line);
+                                }
+
+                                String joined = sb.toString();
+                                tooltipLower = lower(joined);
+                                tooltipText = normalizeTooltip(joined);
+                            }
+
+                            termMatches = tooltipLower.contains(term);
+                        }
+                        break;
+
+                    case MOD:
+                        if (modId == null) {
+                            modId = lower(Platform.getModId(is));
+                        }
+
+                        if (modId.contains(term)) {
+                            termMatches = true;
+                            break;
+                        }
+
+                        if (modName == null) {
+                            modName = getModNameSafe(modId);
+                        }
+                        termMatches = modName.contains(term);
+                        break;
+
+                    case TOOLTIP:
+                        if (tooltipText == null) {
+                            List<String> lines = Platform.getTooltip(is);
+                            StringBuilder sb = new StringBuilder();
+                            for (int i = 0; i < lines.size(); i++) {
+                                String line = lines.get(i);
+                                if (line == null) continue;
+                                if (sb.length() > 0) sb.append('\n');
+                                sb.append(line);
+                            }
+                            String joined = sb.toString();
+                            tooltipLower = lower(joined);
+                            tooltipText = normalizeTooltip(joined);
+                        }
+                        termMatches = tooltipText.contains(normalizeTooltip(term));
+                        break;
+
+                    case OREDICT:
+                        if (stack == null) {
+                            stack = safeItemStack(is);
+                        }
+                        if (!stack.isEmpty()) {
+                            if (oreIds == null) {
+                                oreIds = OreDictionary.getOreIDs(stack);
+                                if (oreIds == null) oreIds = new int[0];
+                            }
+                            for (int id : oreIds) {
+                                String oreName = OreDictionary.getOreName(id);
+                                if (oreName != null && lower(oreName).contains(term)) {
+                                    termMatches = true;
+                                    break;
+                                }
+                            }
+                        }
+                        break;
+
+                    case REGISTRY:
+                        if (stack == null) {
+                            stack = safeItemStack(is);
+                        }
+                        if (!stack.isEmpty()) {
+                            if (registryId == null) {
+                                ResourceLocation rl = stack.getItem() == null ? null : stack.getItem().getRegistryName();
+                                registryId = lower(rl == null ? "" : rl.toString());
+                            }
+                            termMatches = registryId.contains(term);
+                        }
+                        break;
+                }
+
+                boolean passes = neg ? !termMatches : termMatches;
+                if (!passes) {
+                    groupMatches = false;
                     break;
                 }
-            } else if (!dspName.contains(term)) {
-                foundMatchingItemStack = false;
+            }
+
+            if (groupMatches) {
+                found = true;
                 break;
             }
         }
 
-        if (terminalSearchToolTips && !foundMatchingItemStack) {
-            final List<String> tooltip = Platform.getTooltip(is);
-            for (final String line : tooltip) {
-                if (m.matcher(line).find()) {
-                    foundMatchingItemStack = true;
-                    break;
-                }
-            }
-        }
-
-        if (foundMatchingItemStack) {
+        if (found) {
             if (needsZeroCopy) {
                 is = is.copy();
                 is.setStackSize(0);
@@ -255,6 +395,8 @@ public class ItemRepo {
             this.view.add(is);
         }
     }
+
+
 
     private void updateJEI(String filter) {
         Integrations.jei().setSearchText(filter);
@@ -294,5 +436,75 @@ public class ItemRepo {
 
     public IItemList<IAEItemStack> getList() {
         return list;
+    }
+
+
+    private static String lower(String s) {
+        return s == null ? "" : s.toLowerCase(Locale.ROOT);
+    }
+
+    private static String normalizeTooltip(String s) {
+        return lower(s).replace(" ", "");
+    }
+
+    private static ItemStack safeItemStack(IAEItemStack ae) {
+        try {
+            ItemStack s = ae.createItemStack();
+            return s == null ? ItemStack.EMPTY : s;
+        } catch (Throwable t) {
+            try {
+                ItemStack s = ae.getDefinition();
+                return s == null ? ItemStack.EMPTY : s;
+            } catch (Throwable t2) {
+                return ItemStack.EMPTY;
+            }
+        }
+    }
+
+    private static String getModNameSafe(String modId) {
+        if (modId == null || modId.isEmpty()) {
+            return "";
+        }
+
+        try {
+            ModContainer c = Loader.instance().getIndexedModList().get(modId);
+            if (c != null && c.getName() != null) {
+                return lower(c.getName());
+            }
+        } catch (Throwable ignored) {
+        }
+
+        return "";
+    }
+
+    private static List<String> splitSearchTerms(String input) {
+        List<String> out = new ArrayList<>();
+        StringBuilder cur = new StringBuilder();
+        boolean inQuotes = false;
+
+        for (int i = 0; i < input.length(); i++) {
+            char ch = input.charAt(i);
+
+            if (ch == '"') {
+                inQuotes = !inQuotes;
+                continue;
+            }
+
+            if (!inQuotes && Character.isWhitespace(ch)) {
+                if (cur.length() > 0) {
+                    out.add(cur.toString());
+                    cur.setLength(0);
+                }
+                continue;
+            }
+
+            cur.append(ch);
+        }
+
+        if (cur.length() > 0) {
+            out.add(cur.toString());
+        }
+
+        return out;
     }
 }


### PR DESCRIPTION
This PR upgrades ME Terminal searching to support a richer query syntax (OR, scoped prefixes, and quoted terms) while keeping existing view-mode filtering and sorting behavior intact.

## New search syntax
- OR groups using `|`
- Quoted terms using `"..."` to allow spaces inside a single prefix
- Scoped prefixes:
  - `@` searches mod id / mod name
  - `#` searches tooltips
  - `$` searches OreDictionary names
  - `&` or `*` searches registry name (`modid:item`)

## Examples
- `iron gear` (AND)
- `iron | gold` (OR)
- `@thermal ingot`
- `#silk` or `#"silk touch"`
- `$ingotCopper`
- `&minecraft:stone`
- `@"thermal foundation" $ore`

> [!NOTE]
> If you want to try this before it gets merged, you can download a prebuilt jar from the Releases page of my fork: [`NuanKi/Applied-Energistics-2`](https://github.com/NuanKi/Applied-Energistics-2/releases/tag/v0.56.7-7-g891812c).
