### PR TITLE
Pin auto-crafted items to the first row of ME terminals

### DIFF
--- a/src/main/java/appeng/client/ClientHelper.java
+++ b/src/main/java/appeng/client/ClientHelper.java
@@ -23,6 +23,7 @@ import appeng.api.parts.CableRenderMode;
 import appeng.api.util.AEColor;
 import appeng.block.AEBaseBlock;
 import appeng.client.gui.AEBaseGui;
+import appeng.client.me.PinnedKeys;
 import appeng.client.render.crafting.ItemEncodedPatternBakedModel;
 import appeng.client.render.effects.*;
 import appeng.client.render.model.UVLModelLoader;
@@ -69,6 +70,8 @@ import net.minecraftforge.fml.client.registry.RenderingRegistry;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.InputEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent;
+import net.minecraftforge.fml.common.network.FMLNetworkEvent;
 import org.lwjgl.input.Mouse;
 
 import java.io.IOException;
@@ -127,6 +130,22 @@ public class ClientHelper extends ServerHelper {
     @SubscribeEvent
     public void renderWorldLastEvent(RenderWorldLastEvent event) {
         HighlighterHandler.tick(event);
+    }
+
+    @SubscribeEvent
+    public void onClientDisconnect(final FMLNetworkEvent.ClientDisconnectionFromServerEvent event) {
+        PinnedKeys.clearPinnedKeys();
+    }
+
+    @SubscribeEvent
+    public void onClientTick(final TickEvent.ClientTickEvent event) {
+        if (event.phase != TickEvent.Phase.END) {
+            return;
+        }
+
+        if (Minecraft.getMinecraft().currentScreen == null) {
+            PinnedKeys.prune();
+        }
     }
 
     @Override

--- a/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
@@ -34,6 +34,7 @@ import appeng.client.gui.AEBaseMEGui;
 import appeng.client.gui.widgets.*;
 import appeng.client.me.InternalSlotME;
 import appeng.client.me.ItemRepo;
+import appeng.client.me.PinnedKeys;
 import appeng.client.me.SlotME;
 import appeng.container.implementations.ContainerMEMonitorable;
 import appeng.container.slot.AppEngSlot;
@@ -54,6 +55,7 @@ import appeng.tile.misc.TileSecurityStation;
 import appeng.util.IConfigManagerHost;
 import appeng.util.Platform;
 import net.minecraft.client.gui.GuiButton;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
@@ -111,6 +113,7 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
         final GuiScrollbar scrollbar = new GuiScrollbar();
         this.setScrollBar(scrollbar);
         this.repo = new ItemRepo(scrollbar, this);
+        this.repo.setPinnedRowEnabled(true);
 
         this.xSize = 185;
         this.ySize = 204;
@@ -163,7 +166,12 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
 
     private void setScrollBar() {
         this.getScrollBar().setTop(18).setLeft(175).setHeight(this.rows * 18 - 2);
-        this.getScrollBar().setRange(0, (this.repo.size() + this.perRow - 1) / this.perRow - this.rows, Math.max(1, this.rows / 6));
+
+        final int pinnedRows = this.repo.hasPinnedRow() ? 1 : 0;
+        final int viewSize = this.repo.size() - (pinnedRows == 0 ? 0 : this.repo.getPinnedEntries().size());
+        final int viewRows = (viewSize + this.perRow - 1) / this.perRow;
+
+        this.getScrollBar().setRange(0, viewRows - (this.rows - pinnedRows), Math.max(1, this.rows / 6));
     }
 
     @Override
@@ -214,6 +222,8 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
                 .getConfigManager()
                 .getSetting(
                         Settings.TERMINAL_STYLE) != TerminalStyle.FULL ? 9 : 9 + ((this.width - this.standardSize) / 18);
+
+        this.repo.setRowSize(this.perRow);
 
         final int magicNumber = 114 + 1;
         final int extraSpace = this.height - magicNumber - this.reservedSpace;
@@ -385,6 +395,15 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
         super.onGuiClosed();
         Keyboard.enableRepeatEvents(false);
         memoryText = this.searchField.getText();
+
+        for (final IAEItemStack pinned : this.repo.getPinnedEntries()) {
+            final PinnedKeys.PinInfo info = PinnedKeys.getPinInfo(pinned);
+            if (info != null && info.reason == PinnedKeys.PinReason.CRAFTING) {
+                if (!PinnedKeys.hasPendingJob(pinned)) {
+                    info.canPrune = true;
+                }
+            }
+        }
     }
 
     @Override
@@ -404,6 +423,16 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
 
         this.drawTexturedModalRect(offsetX, offsetY + 16 + this.rows * 18 + this.lowerTextureOffset, 0, 106 - 18 - 18, x_width,
                 99 + this.reservedSpace - this.lowerTextureOffset);
+
+        if (this.repo.hasPinnedRow()) {
+            final int highlightLeft = offsetX + this.offsetX;
+            final int highlightTop = offsetY + 18;
+            final int highlightRight = highlightLeft + this.perRow * 18;
+            final int highlightBottom = highlightTop + 18;
+
+            drawRect(highlightLeft, highlightTop, highlightRight, highlightBottom, 0x40FFFF40);
+            GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+        }
 
         if (this.viewCell) {
             boolean update = false;

--- a/src/main/java/appeng/client/me/ItemRepo.java
+++ b/src/main/java/appeng/client/me/ItemRepo.java
@@ -36,7 +36,9 @@ import appeng.util.prioritylist.IPartitionList;
 import net.minecraft.item.ItemStack;
 
 import javax.annotation.Nonnull;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -44,12 +46,20 @@ import java.util.regex.Pattern;
 
 public class ItemRepo {
 
+    private static final Comparator<IAEItemStack> PINNED_ROW_COMPARATOR = Comparator.comparing(stack -> {
+        final PinnedKeys.PinInfo info = PinnedKeys.getPinInfo(stack);
+        return info != null ? info.since : Instant.MAX;
+    });
+
     private final IItemList<IAEItemStack> list = AEApi.instance().storage().getStorageChannel(IItemStorageChannel.class).createList();
     private List<IAEItemStack> view = new ArrayList<>();
+    private final ArrayList<IAEItemStack> pinnedRow = new ArrayList<>();
     private final IScrollSource src;
     private final ISortSource sortSrc;
 
     private int rowSize = 9;
+
+    private boolean pinnedRowEnabled = false;
 
     private String searchString = "";
     private IPartitionList<IAEItemStack> myPartitionList;
@@ -72,6 +82,13 @@ public class ItemRepo {
     }
 
     public IAEItemStack getReferenceItem(int idx) {
+        if (this.pinnedRowEnabled && !this.pinnedRow.isEmpty()) {
+            if (idx < this.rowSize) {
+                return idx < this.pinnedRow.size() ? this.pinnedRow.get(idx) : null;
+            }
+            idx -= this.rowSize;
+        }
+
         idx += this.src.getCurrentScroll() * this.rowSize;
 
         if (idx >= this.view.size()) {
@@ -149,6 +166,7 @@ public class ItemRepo {
             resort = false;
 
             view = new ArrayList<>();
+            pinnedRow.clear();
 
             ItemSorters.setDirection((appeng.api.config.SortDir) sortDir);
             ItemSorters.init();
@@ -158,6 +176,31 @@ public class ItemRepo {
             for (IAEItemStack is : this.list) {
                 addIAE(is, viewMode);
             }
+
+            if (this.pinnedRowEnabled && !PinnedKeys.isEmpty()) {
+                for (IAEItemStack pinnedKey : PinnedKeys.getPinnedKeys()) {
+                    final PinnedKeys.PinInfo info = PinnedKeys.getPinInfo(pinnedKey);
+                    if (info == null || info.reason == PinnedKeys.PinReason.CRAFTING) {
+                        continue;
+                    }
+
+                    boolean alreadyShown = false;
+                    for (IAEItemStack shown : this.pinnedRow) {
+                        if (pinnedKey.isSameType(shown)) {
+                            alreadyShown = true;
+                            break;
+                        }
+                    }
+
+                    if (!alreadyShown) {
+                        final IAEItemStack fake = pinnedKey.copy();
+                        fake.reset();
+                        this.pinnedRow.add(fake);
+                    }
+                }
+            }
+
+            pinnedRow.sort(PINNED_ROW_COMPARATOR);
 
             view.sort(c);
         }
@@ -183,6 +226,13 @@ public class ItemRepo {
     }
 
     private void addIAE(IAEItemStack is, Enum viewMode) {
+
+        final boolean hasPinnedRow = this.pinnedRowEnabled && !PinnedKeys.isEmpty();
+
+        if (hasPinnedRow && this.pinnedRow.size() < this.rowSize && PinnedKeys.isPinned(is)) {
+            this.pinnedRow.add(is);
+            return;
+        }
 
         final boolean needsZeroCopy = viewMode == ViewItems.CRAFTABLE;
 
@@ -261,11 +311,24 @@ public class ItemRepo {
     }
 
     public int size() {
-        return this.view.size();
+        return this.view.size() + this.pinnedRow.size();
     }
 
     public void clear() {
         this.list.resetStatus();
+        this.pinnedRow.clear();
+    }
+
+    public boolean hasPinnedRow() {
+        return this.pinnedRowEnabled && !this.pinnedRow.isEmpty();
+    }
+
+    public List<IAEItemStack> getPinnedEntries() {
+        return Collections.unmodifiableList(this.pinnedRow);
+    }
+
+    public void setPinnedRowEnabled(final boolean pinnedRowEnabled) {
+        this.pinnedRowEnabled = pinnedRowEnabled;
     }
 
     public boolean hasPower() {

--- a/src/main/java/appeng/client/me/PinnedKeys.java
+++ b/src/main/java/appeng/client/me/PinnedKeys.java
@@ -1,0 +1,140 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.client.me;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableSet;
+
+import appeng.api.storage.data.IAEItemStack;
+
+public final class PinnedKeys {
+    public static final int MAX_PINNED = 9;
+
+    private static final Comparator<Map.Entry<IAEItemStack, PinInfo>> TIME_COMPARATOR = new Comparator<Map.Entry<IAEItemStack, PinInfo>>() {
+        @Override
+        public int compare(Map.Entry<IAEItemStack, PinInfo> a, Map.Entry<IAEItemStack, PinInfo> b) {
+            return a.getValue().since.compareTo(b.getValue().since);
+        }
+    };
+
+    private static final Map<IAEItemStack, PinInfo> pinned = new HashMap<IAEItemStack, PinInfo>(MAX_PINNED);
+
+    private static final Set<IAEItemStack> pendingJobs = new HashSet<IAEItemStack>(MAX_PINNED);
+
+    private PinnedKeys() {
+    }
+
+    public static boolean isEmpty() {
+        return pinned.isEmpty();
+    }
+
+    public static Set<IAEItemStack> getPinnedKeys() {
+        return ImmutableSet.copyOf(pinned.keySet());
+    }
+
+    @Nullable
+    public static PinInfo getPinInfo(IAEItemStack key) {
+        return pinned.get(key);
+    }
+
+    public static void clearPinnedKeys() {
+        pinned.clear();
+        pendingJobs.clear();
+    }
+
+    public static void pinKey(IAEItemStack key, PinReason reason) {
+        PinInfo info = pinned.get(key);
+        if (info != null) {
+            info.since = Instant.now();
+        } else {
+            pinned.put(key.copy(), new PinInfo(reason));
+        }
+
+        if (reason == PinReason.CRAFTING) {
+            pendingJobs.add(key.copy());
+        }
+
+        if (pinned.size() > MAX_PINNED) {
+            List<Map.Entry<IAEItemStack, PinInfo>> byAge = new ArrayList<Map.Entry<IAEItemStack, PinInfo>>(pinned.entrySet());
+            Collections.sort(byAge, TIME_COMPARATOR);
+
+            int toRemove = byAge.size() - MAX_PINNED;
+            for (int i = 0; i < toRemove; i++) {
+                IAEItemStack evicted = byAge.get(i).getKey();
+                pinned.remove(evicted);
+                pendingJobs.remove(evicted);
+            }
+        }
+    }
+
+    public static void unpin(IAEItemStack what) {
+        pinned.remove(what);
+        pendingJobs.remove(what);
+    }
+
+    public static boolean isPinned(IAEItemStack what) {
+        return pinned.containsKey(what);
+    }
+
+    public static boolean hasPendingJob(IAEItemStack key) {
+        return pendingJobs.contains(key);
+    }
+
+    public static void markJobDone(IAEItemStack key) {
+        pendingJobs.remove(key);
+    }
+
+    public static void prune() {
+        Iterator<Map.Entry<IAEItemStack, PinInfo>> it = pinned.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<IAEItemStack, PinInfo> entry = it.next();
+            if (entry.getValue().canPrune) {
+                pendingJobs.remove(entry.getKey());
+                it.remove();
+            }
+        }
+    }
+
+    public static class PinInfo {
+        public Instant since;
+        public PinReason reason;
+        public boolean canPrune;
+
+        public PinInfo(PinReason reason) {
+            this.reason = reason;
+            this.since = Instant.now();
+        }
+    }
+
+    public enum PinReason {
+        CRAFTING
+    }
+}

--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -83,6 +83,7 @@ public final class AEConfig extends Configuration implements IConfigurableObject
     private int craftingCalculationTimePerTick = 5;
     private PowerUnits selectedPowerUnit = PowerUnits.AE;
     private boolean showCraftableTooltip = true;
+    private boolean pinAutoCraftedItems = true;
     private boolean showPlacementPreview = true;
     private boolean showCellContentsPreview = true;
 
@@ -259,6 +260,7 @@ public final class AEConfig extends Configuration implements IConfigurableObject
         this.useLargeFonts = this.get("Client", "useTerminalUseLargeFont", false).getBoolean(false);
         this.useColoredCraftingStatus = this.get("Client", "useColoredCraftingStatus", true).getBoolean(true);
         this.showCraftableTooltip = this.get("Client", "showCraftableTooltip", true, "Whether to add \"Craftable\" to item tooltips when they can be crafted automatically.").getBoolean(true);
+        this.pinAutoCraftedItems = this.get("Client", "pinAutoCraftedItems", true, "Whether to pin items that the player auto-crafts to the first row of ME terminals.").getBoolean(true);
         this.showPlacementPreview = this.get("Client", "showPlacementPreview", true, "Whether to show a preview of part and facade placement.").getBoolean(true);
         this.showCellContentsPreview = this.get("Client", "showCellContentsPreview", true, "Whether to show a preview of cell contents in tooltips.").getBoolean(true);
 
@@ -516,6 +518,10 @@ public final class AEConfig extends Configuration implements IConfigurableObject
 
     public boolean isShowCraftableTooltip() {
         return this.showCraftableTooltip;
+    }
+
+    public boolean isPinAutoCraftedItems() {
+        return this.pinAutoCraftedItems;
     }
 
     public boolean showPlacementPreview() {

--- a/src/main/java/appeng/core/sync/AppEngPacketHandlerBase.java
+++ b/src/main/java/appeng/core/sync/AppEngPacketHandlerBase.java
@@ -92,6 +92,8 @@ public class AppEngPacketHandlerBase {
 
         PACKET_CABLE_BUS_LANDING_PARTICLE(PacketCableBusLandingParticle.class),
 
+        PACKET_PIN_CRAFTED_ITEM(PacketPinCraftedItem.class),
+
         ;
 
 

--- a/src/main/java/appeng/core/sync/packets/PacketPinCraftedItem.java
+++ b/src/main/java/appeng/core/sync/packets/PacketPinCraftedItem.java
@@ -1,0 +1,57 @@
+package appeng.core.sync.packets;
+
+import appeng.api.storage.data.IAEItemStack;
+import appeng.client.me.PinnedKeys;
+import appeng.core.AEConfig;
+import appeng.core.sync.AppEngPacket;
+import appeng.core.sync.network.INetworkInfo;
+import appeng.util.item.AEItemStack;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+import java.io.IOException;
+
+public class PacketPinCraftedItem extends AppEngPacket {
+	private final IAEItemStack stack;
+	private final boolean finished;
+
+	public PacketPinCraftedItem(final ByteBuf stream) {
+		this.stack = AEItemStack.fromPacket(stream);
+		this.finished = stream.readBoolean();
+	}
+
+	public PacketPinCraftedItem(IAEItemStack stack, boolean finished) throws IOException {
+		this.stack = stack;
+		this.finished = finished;
+
+		final ByteBuf data = Unpooled.buffer();
+
+		data.writeInt(this.getPacketID());
+		stack.writeToPacket(data);
+		data.writeBoolean(finished);
+
+		this.configureWrite(data);
+	}
+
+	@Override
+	public void clientPacketData(INetworkInfo network, AppEngPacket packet, EntityPlayer player) {
+		if (this.finished || AEConfig.instance().isPinAutoCraftedItems()) {
+			doPinCraftedItem();
+		}
+	}
+
+	@SideOnly(Side.CLIENT)
+	private void doPinCraftedItem() {
+		if (this.finished) {
+			PinnedKeys.markJobDone(this.stack);
+		} else {
+			PinnedKeys.pinKey(this.stack, PinnedKeys.PinReason.CRAFTING);
+		}
+	}
+
+	@Override
+	public void serverPacketData(INetworkInfo manager, AppEngPacket packet, EntityPlayer player) {}
+}

--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
@@ -45,6 +45,7 @@ import appeng.core.AppEng;
 import appeng.core.features.AEFeature;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketCraftingToast;
+import appeng.core.sync.packets.PacketPinCraftedItem;
 import appeng.crafting.*;
 import appeng.helpers.PatternHelper;
 import appeng.me.cache.CraftingGridCache;
@@ -386,22 +387,43 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
         this.elapsedTime = 0;
         this.isComplete = true;
 
+        this.sendPinCraftedItem(true);
         notifyRequester(false);
         this.requestingPlayerUUID = null;
     }
 
     private void notifyRequester(boolean cancelled) {
-        if (!Platform.isServer()) return;
-        if (this.requestingPlayerUUID == null) return;
         if (this.finalOutput == null) return;
         if (!AEConfig.instance().isFeatureEnabled(AEFeature.CRAFTING_TOASTS)) return;
 
+        final EntityPlayerMP playerMP = this.resolveRequestingPlayer();
+        if (playerMP == null) return;
+
+        try {
+            NetworkHandler.instance().sendTo(new PacketCraftingToast(this.finalOutput, cancelled), playerMP);
+        } catch (IOException ignored) {}
+    }
+
+    private void sendPinCraftedItem(boolean finished) {
+        if (this.finalOutput == null) return;
+
+        final EntityPlayerMP playerMP = this.resolveRequestingPlayer();
+        if (playerMP == null) return;
+
+        try {
+            NetworkHandler.instance().sendTo(new PacketPinCraftedItem(this.finalOutput.copy(), finished), playerMP);
+        } catch (IOException ignored) {}
+    }
+
+    private EntityPlayerMP resolveRequestingPlayer() {
+        if (!Platform.isServer()) return null;
+        if (this.requestingPlayerUUID == null) return null;
+
         var player = AppEng.proxy.getPlayerByUUID(this.requestingPlayerUUID);
         if (player instanceof EntityPlayerMP playerMP) {
-            try {
-                NetworkHandler.instance().sendTo(new PacketCraftingToast(this.finalOutput, cancelled), playerMP);
-            } catch (IOException ignored) {}
+            return playerMP;
         }
+        return null;
     }
 
     private void updateCPU() {
@@ -545,6 +567,7 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
             this.postCraftingStatusChange(is);
         }
 
+        this.sendPinCraftedItem(true);
         notifyRequester(true);
         this.requestingPlayerUUID = null;
         this.finalOutput = null;
@@ -835,6 +858,8 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
                 } else {
                     this.requestingPlayerUUID = null;
                 }
+
+                this.sendPinCraftedItem(false);
 
                 this.markDirty();
 


### PR DESCRIPTION
## What

When a player requests a crafting job, the requested item is pinned to the first row of that player's ME terminal. The pin stays until the terminal is closed after the job ends, so the player does not have to search for the result.

## How

| Side | File | Role |
| --- | --- | --- |
| Server | `CraftingCPUCluster` | Sends a packet to the requesting player when a job starts, completes or is cancelled. `resolveRequestingPlayer()` is extracted from the existing `notifyRequester()`. |
| Network | `PacketPinCraftedItem` (new) | Carries the `IAEItemStack` and a `finished` flag. The finished notice is always processed, so a pin cannot get stuck when the option is turned off mid-craft. |
| Network | `AppEngPacketHandlerBase` | Registers the packet type. |
| Client | `PinnedKeys` (new) | Static client-side registry, capped at `MAX_PINNED = 9` (one row), evicting the oldest entry. |
| Client | `ClientHelper` | Clears the registry on disconnect, and prunes it on client tick only while no screen is open. |
| Client | `ItemRepo` | Reserves the first row for pinned entries. Opt-in via `setPinnedRowEnabled()`, off by default so `GuiNetworkStatus` and other consumers are unaffected. |
| Client | `GuiMEMonitorable` | Enables the row, passes `perRow` to `setRowSize()` for `TerminalStyle.FULL`, keeps the pinned row out of the scroll range, and highlights it. |
| Config | `AEConfig` | Adds the `pinAutoCraftedItems` client option, on by default. |

## Notes

- Pinned entries ignore the search box and the view filters, so they stay visible while searching.
- The pinned row does not scroll: it is excluded from the scrollbar range computation.
- `drawRect()` leaves the GL colour tinted, so it is reset to opaque white right after the highlight is drawn.
- The packet is not gated on `AEFeature.CRAFTING_TOASTS`: a player who disabled toasts still gets pinning.
