### PR TITLE
Interface Terminal: persist filter toggles and detect crafting machines properly

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
@@ -72,7 +72,6 @@ public class GuiInterfaceTerminal extends AEBaseGui {
     protected static final int OFFSET_X = 21;
     protected final GuiText guiTitle;
     private static final int MAGIC_HEIGHT_NUMBER = 52 + 99;
-    private static final String MOLECULAR_ASSEMBLER = "tile.appliedenergistics2.molecular_assembler";
 
     private final boolean jeiEnabled;
     private final int jeiButtonPadding;
@@ -82,6 +81,7 @@ public class GuiInterfaceTerminal extends AEBaseGui {
     private final HashMap<ClientDCInternalInv, BlockPos> blockPosHashMap = new HashMap<>();
     private final HashMap<GuiButton, ClientDCInternalInv> guiButtonHashMap = new HashMap<>();
     private final Map<ClientDCInternalInv, Integer> numUpgradesMap = new HashMap<>();
+    private final Map<ClientDCInternalInv, Integer> craftingMachinesMap = new HashMap<>();
     private final ArrayList<String> names = new ArrayList<>();
     private final ArrayList<Object> lines = new ArrayList<>();
     private final Set<Object> matchedStacks = new HashSet<>();
@@ -99,10 +99,10 @@ public class GuiInterfaceTerminal extends AEBaseGui {
 
     private boolean refreshList = false;
 
-    /* These are worded so that the intended default is false */
-    private boolean onlyShowWithSpace = false;
-    private boolean onlyMolecularAssemblers = false;
-    private boolean onlyBrokenRecipes = false;
+    /* These are worded so that the intended default is false, and are remembered across sessions */
+    private boolean onlyShowWithSpace = AEConfig.instance().isInterfaceTerminalOnlyWithSpace();
+    private boolean onlyMolecularAssemblers = AEConfig.instance().isInterfaceTerminalOnlyCraftingMachines();
+    private boolean onlyBrokenRecipes = AEConfig.instance().isInterfaceTerminalOnlyBrokenRecipes();
     private int rows = 6;
 
     public GuiInterfaceTerminal(final InventoryPlayer inventoryPlayer, final PartInterfaceTerminal te) {
@@ -341,12 +341,15 @@ public class GuiInterfaceTerminal extends AEBaseGui {
             mc.player.closeScreen();
         } else if (btn == guiButtonHideFull) {
             onlyShowWithSpace = !onlyShowWithSpace;
+            AEConfig.instance().setInterfaceTerminalOnlyWithSpace(onlyShowWithSpace);
             this.refreshList();
         } else if (btn == guiButtonAssemblersOnly) {
             onlyMolecularAssemblers = !onlyMolecularAssemblers;
+            AEConfig.instance().setInterfaceTerminalOnlyCraftingMachines(onlyMolecularAssemblers);
             this.refreshList();
         } else if (btn == guiButtonBrokenRecipes) {
             onlyBrokenRecipes = !onlyBrokenRecipes;
+            AEConfig.instance().setInterfaceTerminalOnlyBrokenRecipes(onlyBrokenRecipes);
             this.refreshList();
         } else if (btn instanceof GuiImgButton iBtn) {
             if (iBtn.getSetting() != Settings.ACTIONS) {
@@ -475,6 +478,7 @@ public class GuiInterfaceTerminal extends AEBaseGui {
                     blockPosHashMap.put(current, NBTUtil.getPosFromTag(invData.getCompoundTag("pos")));
                     dimHashMap.put(current, invData.getInteger("dim"));
                     numUpgradesMap.put(current, invData.getInteger("numUpgrades"));
+                    craftingMachinesMap.put(current, invData.getInteger("craftingMachines"));
 
                     for (int x = 0; x < current.getInventory().getSlots(); x++) {
                         final String which = Integer.toString(x);
@@ -561,9 +565,10 @@ public class GuiInterfaceTerminal extends AEBaseGui {
                 cachedSearch.remove(entry);
                 continue;
             }
-            // Exit if molecular assembler filter is on and this is not a molecular assembler
-            // Forge documantation said unlocalized name shouldn't be use for logic, so we might need a better way......
-            if (onlyMolecularAssemblers && !entry.getUnlocalizedName().equals(MOLECULAR_ASSEMBLER)) {
+            // Exit if the crafting machine filter is on and no adjacent machine accepts patterns.
+            // The server counts ICraftingMachine neighbours, so this also catches interfaces that carry a
+            // custom name or that sit next to a non-assembler machine on their first face.
+            if (onlyMolecularAssemblers && craftingMachinesMap.getOrDefault(entry, 0) == 0) {
                 cachedSearch.remove(entry);
                 continue;
             }

--- a/src/main/java/appeng/container/implementations/ContainerInterfaceTerminal.java
+++ b/src/main/java/appeng/container/implementations/ContainerInterfaceTerminal.java
@@ -135,7 +135,7 @@ public class ContainerInterfaceTerminal extends AEBaseContainer {
                             missing = true;
                         } else {
                             final DualityInterface dual = ih.getInterfaceDuality();
-                            if (!t.unlocalizedName.equals(dual.getTermName())) {
+                            if (!t.unlocalizedName.equals(dual.getTermName()) || t.craftingMachines != dual.getCraftingMachineCount()) {
                                 missing = true;
                             }
                         }
@@ -157,7 +157,7 @@ public class ContainerInterfaceTerminal extends AEBaseContainer {
                             missing = true;
                         } else {
                             final DualityInterface dual = ih.getInterfaceDuality();
-                            if (!t.unlocalizedName.equals(dual.getTermName())) {
+                            if (!t.unlocalizedName.equals(dual.getTermName()) || t.craftingMachines != dual.getCraftingMachineCount()) {
                                 missing = true;
                             }
                         }
@@ -377,6 +377,7 @@ public class ContainerInterfaceTerminal extends AEBaseContainer {
             tag.setTag("pos", NBTUtil.createPosTag(inv.pos));
             tag.setInteger("dim", inv.dim);
             tag.setInteger("numUpgrades", inv.numUpgrades);
+            tag.setInteger("craftingMachines", inv.craftingMachines);
         }
 
         for (int x = 0; x < length; x++) {
@@ -428,6 +429,7 @@ public class ContainerInterfaceTerminal extends AEBaseContainer {
         private final BlockPos pos;
         private final int dim;
         private final int numUpgrades;
+        private final int craftingMachines;
 
         public InvTracker(final DualityInterface dual, final IItemHandler patterns, final String unlocalizedName) {
             this.server = patterns;
@@ -437,6 +439,7 @@ public class ContainerInterfaceTerminal extends AEBaseContainer {
             this.pos = dual.getLocation().getPos();
             this.dim = dual.getLocation().getWorld().provider.getDimension();
             this.numUpgrades = dual.getInstalledUpgrades(Upgrades.PATTERN_EXPANSION);
+            this.craftingMachines = dual.getCraftingMachineCount();
         }
     }
 

--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -85,6 +85,9 @@ public final class AEConfig extends Configuration implements IConfigurableObject
     private boolean showCraftableTooltip = true;
     private boolean showPlacementPreview = true;
     private boolean showCellContentsPreview = true;
+    private boolean interfaceTerminalOnlyWithSpace = false;
+    private boolean interfaceTerminalOnlyCraftingMachines = false;
+    private boolean interfaceTerminalOnlyBrokenRecipes = false;
 
     // Spatial IO/Dimension
     private int storageProviderID = -1;
@@ -261,6 +264,9 @@ public final class AEConfig extends Configuration implements IConfigurableObject
         this.showCraftableTooltip = this.get("Client", "showCraftableTooltip", true, "Whether to add \"Craftable\" to item tooltips when they can be crafted automatically.").getBoolean(true);
         this.showPlacementPreview = this.get("Client", "showPlacementPreview", true, "Whether to show a preview of part and facade placement.").getBoolean(true);
         this.showCellContentsPreview = this.get("Client", "showCellContentsPreview", true, "Whether to show a preview of cell contents in tooltips.").getBoolean(true);
+        this.interfaceTerminalOnlyWithSpace = this.get("Client", "interfaceTerminalOnlyWithSpace", false, "Remembered state of the Interface Terminal \"only show interfaces with free pattern slots\" filter.").getBoolean(false);
+        this.interfaceTerminalOnlyCraftingMachines = this.get("Client", "interfaceTerminalOnlyCraftingMachines", false, "Remembered state of the Interface Terminal \"only show interfaces attached to crafting machines\" filter.").getBoolean(false);
+        this.interfaceTerminalOnlyBrokenRecipes = this.get("Client", "interfaceTerminalOnlyBrokenRecipes", false, "Remembered state of the Interface Terminal \"only show interfaces with invalid patterns\" filter.").getBoolean(false);
 
         // load buttons..
         for (int btnNum = 0; btnNum < 4; btnNum++) {
@@ -524,6 +530,36 @@ public final class AEConfig extends Configuration implements IConfigurableObject
 
     public boolean showCellContentsPreview() {
         return showCellContentsPreview;
+    }
+
+    public boolean isInterfaceTerminalOnlyWithSpace() {
+        return this.interfaceTerminalOnlyWithSpace;
+    }
+
+    public void setInterfaceTerminalOnlyWithSpace(final boolean value) {
+        this.interfaceTerminalOnlyWithSpace = value;
+        this.get("Client", "interfaceTerminalOnlyWithSpace", false).set(value);
+        this.save();
+    }
+
+    public boolean isInterfaceTerminalOnlyCraftingMachines() {
+        return this.interfaceTerminalOnlyCraftingMachines;
+    }
+
+    public void setInterfaceTerminalOnlyCraftingMachines(final boolean value) {
+        this.interfaceTerminalOnlyCraftingMachines = value;
+        this.get("Client", "interfaceTerminalOnlyCraftingMachines", false).set(value);
+        this.save();
+    }
+
+    public boolean isInterfaceTerminalOnlyBrokenRecipes() {
+        return this.interfaceTerminalOnlyBrokenRecipes;
+    }
+
+    public void setInterfaceTerminalOnlyBrokenRecipes(final boolean value) {
+        this.interfaceTerminalOnlyBrokenRecipes = value;
+        this.get("Client", "interfaceTerminalOnlyBrokenRecipes", false).set(value);
+        this.save();
     }
 
     public boolean isDisableColoredCableRecipesInJEI() {

--- a/src/main/java/appeng/helpers/DualityInterface.java
+++ b/src/main/java/appeng/helpers/DualityInterface.java
@@ -1479,6 +1479,27 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
         return "Nothing";
     }
 
+    /**
+     * Counts the adjacent tiles this interface can push a whole pattern to, i.e. Molecular Assemblers and any
+     * other machine implementing {@link ICraftingMachine}. Used by the Interface Terminal to filter and sort
+     * on actual crafting capacity instead of guessing from the displayed block name.
+     */
+    public int getCraftingMachineCount() {
+        final TileEntity hostTile = this.iHost.getTileEntity();
+        final World hostWorld = hostTile.getWorld();
+        int count = 0;
+
+        for (final EnumFacing direction : this.iHost.getTargets()) {
+            final TileEntity directedTile = hostWorld.getTileEntity(hostTile.getPos().offset(direction));
+
+            if (directedTile instanceof ICraftingMachine && ((ICraftingMachine) directedTile).acceptsPlans()) {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
     public long getSortValue() {
         final TileEntity te = this.iHost.getTileEntity();
         return ((long) te.getPos().getZ() << 24) ^ ((long) te.getPos().getX() << 8) ^ te.getPos().getY();


### PR DESCRIPTION
## Summary

Two related fixes to the ME Interface Terminal.

1. The three filter buttons (free slots / crafting machines / broken recipes) now persist across sessions instead of resetting every time the terminal is opened.
2. The "crafting machines only" filter now uses a server-side neighbour scan instead of comparing the interface's unlocalized name against a hardcoded string.

## Motivation

Encoding a pattern and then finding a free interface is a common loop, and it gets worse as a pack grows. The existing filters already solve most of it, but they reset on every open, and the assembler filter silently misses valid interfaces.

The name comparison in `GuiInterfaceTerminal` was already flagged in a code comment:

> Forge documantation said unlocalized name shouldn't be use for logic, so we might need a better way......

This PR is that better way.

## Changes

### `DualityInterface.getCraftingMachineCount()` (new)

Walks `iHost.getTargets()` and counts adjacent tiles that implement `ICraftingMachine` and return `true` from `acceptsPlans()`. Works for both block interfaces (six faces) and cable parts (one face) without special-casing.

### `ContainerInterfaceTerminal`

- `InvTracker` caches the count next to the existing `numUpgrades`.
- `addItems()` serialises it under the `craftingMachines` NBT key in the per-interface header tag.
- `detectAndSendChanges()` treats a changed count as a reason to regenerate the list, so placing or breaking an assembler with the terminal open is picked up.

### `GuiInterfaceTerminal`

- Removed the `MOLECULAR_ASSEMBLER` constant and the name comparison.
- New `craftingMachinesMap`, populated in `postUpdate()`, mirroring `numUpgradesMap`.
- The three `only*` fields now seed from `AEConfig`, and each toggle in `actionPerformed()` writes the new state back before refreshing.

### `AEConfig`

Three new `Client` options, read in `clientSync()`, each with a getter and a setter that persists:

- `interfaceTerminalOnlyWithSpace`
- `interfaceTerminalOnlyCraftingMachines`
- `interfaceTerminalOnlyBrokenRecipes`

All default to `false`, matching the previous hardcoded values.

## Cases fixed

| Scenario | Before | After |
|---|---|---|
| Chest on the first target face, assembler on the second | filtered out | listed |
| Interface renamed on an anvil | filtered out | listed |
| Non-assembler machine implementing `ICraftingMachine` | never matched | matched |
| Assembler placed or broken with the terminal open | stale result | list regenerates |
| Reopening the terminal after setting filters | toggles reset | toggles restored |

Block interfaces also now report how many crafting machines they are attached to, which opens the door to sorting by crafting capacity later.

## Notes

`getCraftingMachineCount()` runs once per interface per tick per open terminal, doing up to six `getTileEntity` lookups. It sits in the same comparison as `getTermName()`, which already ray-traces on every one of those iterations, so the relative cost is small. If that loop is ever optimised, both calls should be cached together.

## Compatibility

No world data touched. The new NBT key lives in the terminal's transient sync payload, and the config keys are created with the previous defaults, so existing installs behave identically until a player changes a filter.
